### PR TITLE
Number of rows formats.

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -33,7 +33,7 @@ export function cost(value: number): string {
 }
 
 export function rows(value: number): string {
-  return numeral(value).format('Oa');
+  return numeral(value).format('0,0[.]00');
 }
 
 export function factor(value: number): string {

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,5 +1,7 @@
 import * as _ from 'lodash';
 import numeral from 'numeral';
+import 'numeral/locales';
+numeral.locale(navigator.language || 'en');
 import { EstimateDirection, NodeProp, nodePropTypes, PropType } from '@/enums';
 
 export function duration(value: number): string {


### PR DESCRIPTION
Don't use abbreviations for number of rows (ie. k, m, b) because it makes it harder to read.
With this PR, cost and number of rows is formatted using browser locale.
![Capture du 2019-08-07 15-06-48](https://user-images.githubusercontent.com/319774/62625255-1fcd7d80-b925-11e9-9433-bc2aec81eaeb.png)
![Capture du 2019-08-07 15-07-11](https://user-images.githubusercontent.com/319774/62625257-1fcd7d80-b925-11e9-92e9-e04dcc7c5d34.png)
