### PR TITLE
Handle Workers duplicated key in JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3269,6 +3269,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clarinet": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.3.tgz",
+      "integrity": "sha512-Vdv6MsBQWppWUCe/5EGa6JSYln0coSK98NsLAAbdqM3uTXmySZoGQXAMDgOAOlf5wjSIdeHVx9jhjkXOVDvoIA=="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/highlight.js": "^9.12.3",
     "@types/lodash": "^4.14.123",
     "axios": "^0.19.0",
+    "clarinet": "^0.12.3",
     "core-js": "^3.1.4",
     "highlight.js": "^9.15.6",
     "lodash": "^4.17.15",

--- a/src/clarinet.d.ts
+++ b/src/clarinet.d.ts
@@ -1,0 +1,1 @@
+declare module 'clarinet';

--- a/src/services/__tests__/06-json-duplicated-keys.spec.ts
+++ b/src/services/__tests__/06-json-duplicated-keys.spec.ts
@@ -1,0 +1,49 @@
+import { PlanService } from '@/services/plan-service';
+
+describe('PlanService', () => {
+  test('correctly handles duplicated keys in JSON', () => {
+    const planService = new PlanService();
+    const source = `
+[
+  {
+    "Plan": {
+      "Workers": [
+        {
+          "Worker Number": 0,
+          "Sort Method": "external merge",
+          "Sort Space Used": 73552,
+          "Sort Space Type": "Disk"
+        },
+        {
+          "Worker Number": 1,
+          "Sort Method": "external merge",
+          "Sort Space Used": 73320,
+          "Sort Space Type": "Disk"
+        }
+      ],
+      "Workers": [
+        {
+          "Worker Number": 0,
+          "Actual Startup Time": 1487.846,
+          "Actual Total Time": 1996.879,
+          "Actual Rows": 2692973,
+          "Actual Loops": 1
+        },
+        {
+          "Worker Number": 1,
+          "Actual Startup Time": 1468.256,
+          "Actual Total Time": 2012.744,
+          "Actual Rows": 2684443,
+          "Actual Loops": 1
+        }
+      ],
+      "Plan Width": 36
+    }
+  }
+]`;
+    const json: any = planService.parseJson(source);
+    expect(json[0].Plan.Workers.length).toEqual(2);
+    expect(json[0].Plan.Workers[0]['Sort Method']).toEqual('external merge');
+    expect(json[0].Plan.Workers[0]['Actual Startup Time']).toEqual(1487.846);
+  });
+});

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -4,6 +4,7 @@ import { IPlan } from '@/iplan';
 import Node from '@/inode';
 import Worker from '@/iworker';
 import moment from 'moment';
+import clarinet from 'clarinet';
 
 export class PlanService {
 
@@ -200,11 +201,71 @@ export class PlanService {
 
     const useSource: string = sourceLines.slice(firstLineIndex, lastLineIndex + 1).join('\n');
 
-    let planJson = JSON.parse(useSource);
+    let planJson = this.parseJson(useSource);
     if (planJson instanceof Array) {
       planJson = planJson[0];
     }
     return planJson;
+  }
+
+  // Stream parse JSON as it can contain duplicate keys (workers)
+  public parseJson(source: string) {
+    const parser = clarinet.parser();
+    const elements: any[] = [];
+    let root: any = null;
+    // Store the level and duplicated object|array
+    let duplicated: [number, any] | null = null;
+    parser.onvalue = (v: any) => {
+      const current = elements[elements.length - 1];
+      if (_.isArray(current)) {
+        current.push(v);
+      } else {
+        const keys = Object.keys(current);
+        const lastKey = keys[keys.length - 1];
+        current[lastKey] = v;
+      }
+    };
+    parser.onopenobject = (key: any) => {
+      const o: {[key: string]: any} = {};
+      o[key] = null;
+      elements.push(o);
+    };
+    parser.onkey = (key: any) => {
+      const current = elements[elements.length - 1];
+      const keys = Object.keys(current);
+      if (keys.indexOf(key) !== -1) {
+        duplicated = [elements.length - 1, current[key]];
+      } else {
+        current[key] = null;
+      }
+    };
+    parser.onopenarray = () => {
+      elements.push([]);
+    };
+    parser.oncloseobject = parser.onclosearray = () => {
+      const popped = elements.pop();
+
+      if (!elements.length) {
+        root = popped;
+      } else {
+        const current = elements[elements.length - 1];
+
+        if (duplicated && duplicated[0] === elements.length - 1) {
+          _.merge(duplicated[1], popped);
+          duplicated = null;
+        } else {
+          if (_.isArray(current)) {
+            current.push(popped);
+          } else {
+            const keys = Object.keys(current);
+            const lastKey = keys[keys.length - 1];
+            current[lastKey] = popped;
+          }
+        }
+      }
+    };
+    parser.write(source).close();
+    return root;
   }
 
   public fromText(text: string) {


### PR DESCRIPTION
In some plans when there is parallelism and mode is verbose, the "Workers" key may be duplicated in some objects.
Parsing the string using `JSON.parse` results in some data being lost since keys should be unique in JSON format. Issue has been reported in pgsql-hackers list.

With the current PR, data is merged when duplicated keys are detected.

```JSON
[
  {
    "Plan": {
      "Node Type": "Gather Merge",
      "Parallel Aware": false,
      "Actual Startup Time": 1720.052,
      "Actual Total Time": 4252.290,
      "Actual Rows": 10000000,
      "Actual Loops": 1,
      "Output": ["c1", "c2"],
      "Workers Planned": 2,
      "Workers Launched": 2,
      "Plans": [
        {
          "Node Type": "Sort",
          "Parent Relationship": "Outer",
          "Parallel Aware": false,
          "Actual Startup Time": 1558.638,
          "Actual Total Time": 2127.522,
          "Actual Rows": 3333333,
          "Actual Loops": 3,
          "Output": ["c1", "c2"],
          "Sort Key": ["t1.c1"],
          "Sort Method": "external merge",
          "Sort Space Used": 126152,
          "Sort Space Type": "Disk",
          "Workers": [
            {
              "Worker Number": 0,
              "Sort Method": "external merge",
              "Sort Space Used": 73552,
              "Sort Space Type": "Disk"
            },
            {
              "Worker Number": 1,
              "Sort Method": "external merge",
              "Sort Space Used": 73320,
              "Sort Space Type": "Disk"
            }
          ],
          "Workers": [
            {
              "Worker Number": 0,
              "Actual Startup Time": 1487.846,
              "Actual Total Time": 1996.879,
              "Actual Rows": 2692973,
              "Actual Loops": 1
            },
            {
              "Worker Number": 1,
              "Actual Startup Time": 1468.256,
              "Actual Total Time": 2012.744,
              "Actual Rows": 2684443,
              "Actual Loops": 1
            }
          ],
          "Plans": [
            {
              "Node Type": "Seq Scan",
              "Parent Relationship": "Outer",
              "Parallel Aware": true,
              "Relation Name": "t1",
              "Schema": "public",
              "Alias": "t1",
              "Actual Startup Time": 0.211,
              "Actual Total Time": 372.858,
              "Actual Rows": 3333333,
              "Actual Loops": 3,
              "Output": ["c1", "c2"],
              "Workers": [
                {
                  "Worker Number": 0,
                  "Actual Startup Time": 0.029,
                  "Actual Total Time": 368.356,
                  "Actual Rows": 2692973,
                  "Actual Loops": 1
                },
                {
                  "Worker Number": 1,
                  "Actual Startup Time": 0.033,
                  "Actual Total Time": 368.874,
                  "Actual Rows": 2684443,
                  "Actual Loops": 1
                }
              ]
            }
          ]
        }
      ]
    },
    "Planning Time": 0.170,
    "Triggers": [
    ],
    "Execution Time": 4695.141
  }
]
```