### PR TITLE
Workers no analyze

### DIFF
--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -465,7 +465,8 @@ export default class PlanNode extends Vue {
   }
 
   private get allWorkersLaunched(): boolean {
-    return this.node[NodeProp.WORKERS_PLANNED] === this.node[NodeProp.WORKERS_LAUNCHED];
+    return !this.node[NodeProp.WORKERS_LAUNCHED] ||
+      this.node[NodeProp.WORKERS_PLANNED] === this.node[NodeProp.WORKERS_LAUNCHED];
   }
 
   private getHelpMessage(message: string) {

--- a/src/services/__tests__/07-bis-no-analyze-workers.spec.ts
+++ b/src/services/__tests__/07-bis-no-analyze-workers.spec.ts
@@ -1,0 +1,23 @@
+import { PlanService } from '@/services/plan-service';
+import { IPlan } from '@/iplan';
+
+describe('PlanService', () => {
+  test('Workers taken into account', () => {
+    const planService = new PlanService();
+    const source = `
+ Finalize Aggregate  (cost=2734224.57..2734224.58 rows=1 width=8)
+   ->  Gather  (cost=2734223.33..2734224.54 rows=12 width=8)
+         Workers Planned: 12
+         ->  Partial Aggregate  (cost=2733223.33..2733223.34 rows=1 width=8)
+               ->  Parallel Seq Scan on bigtable  (cost=0.00..2629056.67 rows=41666667 width=0)
+ JIT:
+   Functions: 4
+   Options: Inlining true, Optimization true, Expressions true, Deforming true
+(8 lignes)
+`;
+    const r: any = planService.fromSource(source);
+    const plan: IPlan = planService.createPlan('', r, '');
+    const aggregateNode = plan.content.Plan.Plans[0].Plans[0].Plans[0];
+    expect(aggregateNode.Workers).toEqual(12);
+  });
+});

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -54,7 +54,12 @@ export class PlanService {
       // All children of Gather node will be considered parallel
       // Pass the number of workers launched to children
       if (!child[NodeProp.WORKERS]) {
-        child[NodeProp.WORKERS] = node[NodeProp.WORKERS_LAUNCHED] || node[NodeProp.WORKERS];
+        let workersLaunched;
+        if (node[NodeProp.WORKERS_PLANNED]) {
+          // Launched workers info may not be available (ie. no analyze)
+          workersLaunched = node[NodeProp.WORKERS_LAUNCHED] || node[NodeProp.WORKERS_PLANNED];
+        }
+        child[NodeProp.WORKERS] = workersLaunched || node[NodeProp.WORKERS];
       }
       this.processNode(child);
     });


### PR DESCRIPTION
Fixes #95 

The workers count for child nodes of a Gather node are assumed to be the same as planned when the EXPLAIN command has not been executed with ANALYZE.

![Capture du 2019-10-25 15-35-07](https://user-images.githubusercontent.com/319774/67575531-0fb38600-f73d-11e9-9b4b-b0ea8c5f13b6.png)

Also the "Not all workers launched" will never appear in this case.
