### PR TITLE
Make sure estimation direction is not hidden

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -6,9 +6,9 @@ export class HighlightType {
 }
 
 export enum EstimateDirection {
-    over,
-    under,
-    none,
+  over = 1,
+  under = 2,
+  none = 3,
 }
 
 export class ViewMode {


### PR DESCRIPTION
Because Estimation.under == 0, it was removed from detailed view
Fixes #102