### PR TITLE
Use link instead of button for new plan

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app" class="d-flex flex-column vh-100">
     <div class="navbar container">
-      <router-link tag="button" class="btn btn-secondary ml-auto" to="/">
+      <router-link tag="a" class="btn btn-secondary ml-auto" to="/">
         New Plan
       </router-link>
       <router-link tag="a" class="btn btn-link" to="about">


### PR DESCRIPTION
Allows to open link in new tab w/ ctrl-click
Fixes #109