### PR TITLE
Consider negative duration as null

### DIFF
--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -148,7 +148,8 @@ export class PlanService {
         node[NodeProp.ACTUAL_DURATION] = node[NodeProp.ACTUAL_DURATION] * node[NodeProp.ACTUAL_LOOPS];
       }
 
-      node[NodeProp.ACTUAL_DURATION] = node[NodeProp.ACTUAL_DURATION] - this.childrenDuration(node, 0);
+      const duration = node[NodeProp.ACTUAL_DURATION] - this.childrenDuration(node, 0);
+      node[NodeProp.ACTUAL_DURATION] = duration > 0 ? duration : 0;
     }
 
     if (node[NodeProp.TOTAL_COST]) {


### PR DESCRIPTION
Fixes #113

In some conditions, sum of the children duration is greater that the duration of current node. This leads to negative duration. The current PR adds a workaround to avoid this. This is cheating but better than showing negative durations.