### PR TITLE
Use max total cost for cost percent

### DIFF
--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -243,8 +243,8 @@ export default class PlanNode extends Vue {
   }
 
   private calculateCost() {
-    const planCost = this.plan.content.Plan[NodeProp.TOTAL_COST];
-    this.costPercent = _.round((this.node[NodeProp.ACTUAL_COST] / planCost) * 100);
+    const maxTotalCost = this.plan.content.maxTotalCost;
+    this.costPercent = _.round((this.node[NodeProp.ACTUAL_COST] / maxTotalCost) * 100);
   }
 
   private calculateRowsRemoved() {

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -91,6 +91,11 @@ export class PlanService {
       content.costliest = costliest;
     }
 
+    const totalCostliest = _.maxBy(flat, NodeProp.TOTAL_COST);
+    if (totalCostliest) {
+      content.maxTotalCost = totalCostliest[NodeProp.TOTAL_COST];
+    }
+
     const slowest = _.maxBy(flat, NodeProp.ACTUAL_DURATION);
     if (slowest) {
       slowest[NodeProp.SLOWEST_NODE] = true;


### PR DESCRIPTION
Not root node total cost
For example if the root node is a Limit Node, its total cost
may not be the maximum.

Prevents >100% cost.
![Capture du 2020-06-02 09-01-55](https://user-images.githubusercontent.com/319774/83490152-d0f26500-a4af-11ea-9481-ba6f3922bda2.png)
