### PR TITLE
Detail layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,16 +68,13 @@
   },
   "lint-staged": {
     "*.ts": [
-      "vue-cli-service lint",
-      "git add"
+      "vue-cli-service lint"
     ],
     "*.vue": [
-      "vue-cli-service lint",
-      "git add"
+      "vue-cli-service lint"
     ],
     "*.{js,css,json,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "husky": {

--- a/src/assets/scss/_plan-node.scss
+++ b/src/assets/scss/_plan-node.scss
@@ -234,7 +234,7 @@ ul.node-children.collapsed {
   .plan-node {
     display: block;
     .plan-node-body {
-      height: 0;
+      height: $compact-width / 3;
       * {
         display: none;
       }

--- a/src/assets/scss/_plan-node.scss
+++ b/src/assets/scss/_plan-node.scss
@@ -26,10 +26,26 @@ $bg-color: #fff;
     position: relative;
     border: 1px solid $line-color;
     border-radius: $border-radius-base;
-    padding: $padding-base $padding-lg;
     background-color: $plan-node-bg;
     box-shadow: 1px 1px 3px 0px rgba(0,0,0,0.1);
     cursor: auto;
+
+    &.card {
+      .card-body, .card-header {
+        padding: $padding-base $padding-lg;
+      }
+
+      .card-header .card-header-tabs {
+        margin-right: 0;
+        margin-left: 0;
+        margin-bottom: -$padding-base;
+        margin-top: $padding-base;
+
+        .nav-link {
+          padding: $padding-base / 2 $padding-lg;
+        }
+      }
+    }
   }
 
   &.parallel .plan-node-body {
@@ -80,7 +96,6 @@ $bg-color: #fff;
   .node-description {
     text-align: left;
     font-style: italic;
-    padding-top: $padding-lg;
     word-break: normal;
 
     .node-type {

--- a/src/assets/scss/_plan.scss
+++ b/src/assets/scss/_plan.scss
@@ -268,22 +268,20 @@ $connector-line: 2px solid darken($line-color, 10%);
     font-size: $font-size-sm;
   }
 
-  .accordion {
-    button {
-      .fa-chevron-right {
-        display: inline-block;
-      }
-      .fa-chevron-down {
-        display: none;
-      }
+  button {
+    .fa-chevron-right {
+      display: inline-block;
     }
-    button[aria-expanded='true'] {
-      .fa-chevron-right {
-        display: none !important;
-      }
-      .fa-chevron-down {
-        display: inline-block !important;
-      }
+    .fa-chevron-down {
+      display: none;
+    }
+  }
+  button[aria-expanded='true'] {
+    .fa-chevron-right {
+      display: none !important;
+    }
+    .fa-chevron-down {
+      display: inline-block !important;
     }
   }
 }

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -108,6 +108,7 @@
               </template>
             </div>
             <div>
+              <i class="fa fa-fw fa-align-justify text-muted"></i>
               <b>Rows:</b> <span class="px-1">{{ formattedProp('ACTUAL_ROWS') }}</span> <span class="text-muted">(Planned: {{ formattedProp('PLAN_ROWS') }})</span>
               <span v-if="plannerRowEstimateDirection !== estimateDirections.none && shouldShowPlannerEstimate">
                 |
@@ -120,6 +121,7 @@
               </span>
             </div>
             <div v-if="rowsRemoved">
+              <i class="fa fa-fw fa-filter text-muted"></i>
               <b>
                 Rows removed by filter:
               </b>
@@ -129,9 +131,11 @@
               </span>
             </div>
             <div>
+              <i class="fa fa-fw fa-dollar-sign text-muted"></i>
               <b>Cost:</b> <span :class="'p-0 px-1 mr-1 alert ' + costClass">{{ formattedProp('EXCLUSIVE_COST') }}</span> <span class="text-muted">(Total: {{ formattedProp('TOTAL_COST') }})</span>
             </div>
             <div v-if="node[nodeProps.ACTUAL_LOOPS] > 1">
+              <i class="fa fa-fw fa-undo text-muted"></i>
               <b>Loops:</b> <span class="px-1">{{ formattedProp('ACTUAL_LOOPS') }}
               </span>            </div>
             <!-- general tab -->

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -19,16 +19,7 @@
               {{ getNodeName() }}
             </h4>
             <span v-if="viewOptions.viewMode === viewModes.FULL">
-              <span class="node-duration" v-if="node[nodeProps.EXCLUSIVE_DURATION]">
-                <span :class="'p-0 px-1 rounded alert ' + durationClass"
-                      v-html="formattedProp('EXCLUSIVE_DURATION')">
-                </span>
-                <template v-if="executionTimePercent !== Infinity">
-                  |
-                  <strong>{{executionTimePercent}}</strong><span class="text-muted">%</span>
-                </template>
-              </span>
-              <span class="node-duration text-warning" v-else-if="isNeverExecuted">
+              <span class="node-duration text-warning" v-if="isNeverExecuted">
                 Never executed
               </span>
             </span>
@@ -107,6 +98,15 @@
         <div class="card-body tab-content" v-if="showDetails">
           <div class="tab-pane" :class="{'show active': activeTab === 'general' }">
             <!-- general -->
+            <div v-if="node[nodeProps.EXCLUSIVE_DURATION]">
+              <i class="fa fa-fw fa-clock text-muted"></i>
+              <b>Timing:</b>&nbsp;
+              <span :class="'p-0 px-1 rounded alert ' + durationClass" v-html="formattedProp('EXCLUSIVE_DURATION')"></span>
+              <template v-if="executionTimePercent !== Infinity">
+                |
+                <strong>{{executionTimePercent}}</strong><span class="text-muted">%</span>
+              </template>
+            </div>
             <div>
               <b>Rows:</b> <span class="px-1">{{ formattedProp('ACTUAL_ROWS') }}</span> <span class="text-muted">(Planned: {{ formattedProp('PLAN_ROWS') }})</span>
               <span v-if="plannerRowEstimateDirection !== estimateDirections.none && shouldShowPlannerEstimate">

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -314,6 +314,59 @@ export default class PlanNode extends Vue {
   private colorService = new ColorService();
   private lodash = _;
 
+  // Returns the list of properties that have already been displayed either in
+  // the main panel or in other detailed tabs.
+  private notMiscProperties: string[] = [
+      NodeProp.NODE_TYPE,
+      NodeProp.CTE_NAME,
+      NodeProp.EXCLUSIVE_DURATION,
+      NodeProp.EXCLUSIVE_COST,
+      NodeProp.TOTAL_COST,
+      NodeProp.PLAN_ROWS,
+      NodeProp.ACTUAL_ROWS,
+      NodeProp.ACTUAL_LOOPS,
+      NodeProp.OUTPUT,
+      NodeProp.WORKERS,
+      NodeProp.WORKERS_PLANNED,
+      NodeProp.WORKERS_LAUNCHED,
+      NodeProp.EXCLUSIVE_SHARED_HIT_BLOCKS,
+      NodeProp.EXCLUSIVE_SHARED_READ_BLOCKS,
+      NodeProp.EXCLUSIVE_SHARED_DIRTIED_BLOCKS,
+      NodeProp.EXCLUSIVE_SHARED_WRITTEN_BLOCKS,
+      NodeProp.EXCLUSIVE_TEMP_HIT_BLOCKS,
+      NodeProp.EXCLUSIVE_TEMP_READ_BLOCKS,
+      NodeProp.EXCLUSIVE_TEMP_DIRTIED_BLOCKS,
+      NodeProp.EXCLUSIVE_TEMP_WRITTEN_BLOCKS,
+      NodeProp.EXCLUSIVE_LOCAL_HIT_BLOCKS,
+      NodeProp.EXCLUSIVE_LOCAL_READ_BLOCKS,
+      NodeProp.EXCLUSIVE_LOCAL_DIRTIED_BLOCKS,
+      NodeProp.EXCLUSIVE_LOCAL_WRITTEN_BLOCKS,
+      NodeProp.SHARED_HIT_BLOCKS,
+      NodeProp.SHARED_READ_BLOCKS,
+      NodeProp.SHARED_DIRTIED_BLOCKS,
+      NodeProp.SHARED_WRITTEN_BLOCKS,
+      NodeProp.TEMP_HIT_BLOCKS,
+      NodeProp.TEMP_READ_BLOCKS,
+      NodeProp.TEMP_DIRTIED_BLOCKS,
+      NodeProp.TEMP_WRITTEN_BLOCKS,
+      NodeProp.LOCAL_HIT_BLOCKS,
+      NodeProp.LOCAL_READ_BLOCKS,
+      NodeProp.LOCAL_DIRTIED_BLOCKS,
+      NodeProp.LOCAL_WRITTEN_BLOCKS,
+      NodeProp.PLANNER_ESTIMATE_FACTOR,
+      NodeProp.PLANNER_ESTIMATE_DIRECTION,
+      NodeProp.SUBPLAN_NAME,
+      NodeProp.GROUP_KEY,
+      NodeProp.HASH_CONDITION,
+      NodeProp.JOIN_TYPE,
+      NodeProp.INDEX_NAME,
+      NodeProp.HASH_CONDITION,
+      NodeProp.EXCLUSIVE_IO_READ_TIME,
+      NodeProp.EXCLUSIVE_IO_WRITE_TIME,
+      NodeProp.IO_READ_TIME, // Exclusive value already shown in IO tab
+      NodeProp.IO_WRITE_TIME, // Exclusive value already shown in IO tab
+  ];
+
   private created(): void {
     this.calculateProps();
     this.calculateBar();
@@ -552,8 +605,11 @@ export default class PlanNode extends Vue {
   }
 
   private shouldShowProp(key: string, value: any): boolean {
-    return value || nodePropTypes[key] === PropType.increment ||
-      key === NodeProp.ACTUAL_ROWS;
+
+    return (value ||
+            nodePropTypes[key] === PropType.increment ||
+            key === NodeProp.ACTUAL_ROWS) &&
+           this.notMiscProperties.indexOf(key) === -1;
   }
 
   private get isNeverExecuted(): boolean {

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -75,10 +75,10 @@
           </div>
 
           <div>
-            <span v-if="durationClass" :class="'p-0 px-1 d-inline-block mb-1 mr-1 text-nowrap alert ' + durationClass">Slow</span>
-            <span v-if="costClass" :class="'p-0 px-1 d-inline-block mb-1 mr-1 text-nowrap alert ' + costClass">Expensive</span>
-            <span v-if="estimationClass" :class="'p-0 px-1 d-inline-block mb-1 mr-1 text-nowrap alert ' + estimationClass">Bad est.</span>
-            <span v-if="rowsRemovedClass" :class="'p-0 px-1 d-inline-block mb-1 mr-1 text-nowrap alert ' + rowsRemovedClass">Rows removed</span>
+            <span v-if="durationClass" :class="'p-0  d-inline-block mb-1 mr-1 text-nowrap alert ' + durationClass" title="Slow"><i class="fa fa-fw fa-clock"></i></span>
+            <span v-if="costClass" :class="'p-0  d-inline-block mb-1 mr-1 text-nowrap alert ' + costClass" title="Cost is high"><i class="fa fa-fw fa-dollar-sign"></i></span>
+            <span v-if="estimationClass" :class="'p-0  d-inline-block mb-1 mr-1 text-nowrap alert ' + estimationClass" title="Bad estimation for number of rows"><i class="fa fa-fw fa-thumbs-down"></i></span>
+            <span v-if="rowsRemovedClass" :class="'p-0  d-inline-block mb-1 mr-1 text-nowrap alert ' + rowsRemovedClass" title="High number of rows removed"><i class="fa fa-fw fa-filter"></i></span>
           </div>
         </div>
 

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -197,10 +197,10 @@
           </div>
           <div class="tab-pane" :class="{'show active': activeTab === 'workers' }" v-if="workersCount">
 
+            <!-- workers tab -->
             <div v-if="lodash.isNumber(workersCount) && !lodash.isNaN(workersCount) && viewOptions.viewMode === viewModes.FULL">
               <b>Workers: </b> <span class="px-1">{{ workersCount }}</span>
             </div>
-            <!-- workers tab -->
             <div class="accordion" v-if="lodash.isArray(node[nodeProps.WORKERS])">
               <template v-for="(worker, index) in node[nodeProps.WORKERS]">
                 <div class="card">

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -201,7 +201,7 @@
               <b>Workers: </b> <span class="px-1">{{ workersCount }}</span>
             </div>
             <!-- workers tab -->
-            <div class="accordion" :id="'accordion-' + _uid" v-if="lodash.isArray(node[nodeProps.WORKERS])">
+            <div class="accordion" v-if="lodash.isArray(node[nodeProps.WORKERS])">
               <template v-for="(worker, index) in node[nodeProps.WORKERS]">
                 <div class="card">
                   <div class="card-header p-0">
@@ -212,7 +212,7 @@
                     </button>
                   </div>
 
-                  <div :id="'collapse-' + _uid + '-' + index" class="collapse" :data-parent="'#accordion-' + _uid">
+                  <div :id="'collapse-' + _uid + '-' + index" class="collapse">
                     <div class="card-body p-0">
                       <table class="table table-sm prop-list mb-0">
                         <tr v-for="(value, key) in worker" v-if="shouldShowProp(key, value)">

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -179,6 +179,9 @@ nodePropTypes[NodeProp.PLANNER_ESTIMATE_DIRECTION] = PropType.estimateDirection;
 nodePropTypes[NodeProp.IO_READ_TIME] = PropType.duration;
 nodePropTypes[NodeProp.IO_WRITE_TIME] = PropType.duration;
 
+nodePropTypes[NodeProp.EXCLUSIVE_IO_READ_TIME] = PropType.duration;
+nodePropTypes[NodeProp.EXCLUSIVE_IO_WRITE_TIME] = PropType.duration;
+
 export class WorkerProp {
   // plan property keys
   public static WORKER_NUMBER: string = 'Worker Number';

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -107,12 +107,9 @@ export enum NodeProp {
   OUTPUT = 'Output',
 
   // computed by pev
-  COSTLIEST_NODE = '*Costiest Node (by cost)',
-  LARGEST_NODE = '*Largest Node (by rows)',
-  SLOWEST_NODE = '*Slowest Node (by duration)',
-
   EXCLUSIVE_DURATION = '*Duration (exclusive)',
   EXCLUSIVE_COST = '*Cost (exclusive)',
+
   PLANNER_ESTIMATE_FACTOR = '*Planner Row Estimate Factor',
   PLANNER_ESTIMATE_DIRECTION = '*Planner Row Estimate Direction',
 
@@ -167,12 +164,9 @@ nodePropTypes[NodeProp.SORT_SPACE_USED] = PropType.space;
 nodePropTypes[NodeProp.ROWS_REMOVED_BY_FILTER] = PropType.rows;
 nodePropTypes[NodeProp.ROWS_REMOVED_BY_JOIN_FILTER] = PropType.rows;
 
-nodePropTypes[NodeProp.COSTLIEST_NODE] = PropType.boolean;
-nodePropTypes[NodeProp.LARGEST_NODE] = PropType.boolean;
-nodePropTypes[NodeProp.SLOWEST_NODE] = PropType.boolean;
-
 nodePropTypes[NodeProp.EXCLUSIVE_DURATION] = PropType.duration;
 nodePropTypes[NodeProp.EXCLUSIVE_COST] = PropType.cost;
+
 nodePropTypes[NodeProp.PLANNER_ESTIMATE_FACTOR] = PropType.factor;
 nodePropTypes[NodeProp.PLANNER_ESTIMATE_DIRECTION] = PropType.estimateDirection;
 


### PR DESCRIPTION
This PR's main goal is to make detail info less messy and easier to read with information tidied up in tabs instead of a single table with unsorted rows.

![Capture du 2020-06-04 12-12-52](https://user-images.githubusercontent.com/319774/83745557-01780180-a65e-11ea-86b2-2fa67a12dbb1.png)


I'm looking for feedback.

The result can be temporarily seen at http://bluecarto.free.fr/pev2/detail_layout