### PR TITLE
Don't try to parse plans without analyze nor costs

### DIFF
--- a/src/services/__tests__/08-plan-without-cost.spec.ts
+++ b/src/services/__tests__/08-plan-without-cost.spec.ts
@@ -16,7 +16,7 @@ Seq Scan on pg_class (actual time=0.013..0.181 rows=645 loops=1)
 
 
 describe('PlanService', () => {
-  test('Can parse plan without analyze nor costs', () => {
+  test('Cannot parse plan without analyze nor costs', () => {
     const planService = new PlanService();
     const source = `
 Bitmap Heap Scan on a
@@ -27,6 +27,6 @@ Bitmap Heap Scan on a
          ->  Bitmap Index Scan on a_pkey
                Index Cond: (id = 4711)
 `;
-    const r: any = planService.fromSource(source);
+    expect(() => { planService.fromText(source); }).toThrow();
   });
 });

--- a/src/services/__tests__/1-parse-error-line-break.spec.ts
+++ b/src/services/__tests__/1-parse-error-line-break.spec.ts
@@ -1,4 +1,5 @@
 import { PlanService } from '@/services/plan-service';
+import { IPlan } from '@/iplan';
 
 describe('PlanService', () => {
   test('Can`t parse plan with line break', () => {
@@ -18,7 +19,9 @@ Nested Loop Left Join  (cost=11.95..28.52 rows=5 width=157) (actual time=0.010..
 here is a line break
 Planning Time: 1.110 ms
 Execution Time: 0.170 ms`;
-    expect(() => { planService.fromText(source); }).toThrow();
+    const r: any = planService.fromSource(source);
+    const plan: IPlan = planService.createPlan('', r, '');
+    expect(plan.content['Planning Time']).toBe(1.11);
   });
 
 });

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -423,7 +423,7 @@ export class PlanService {
           nonCapturingGroupOpen + estimationRegex + nonCapturingGroupClose +
           '|' +
           nonCapturingGroupOpen + openParenthesisRegex + actualRegex + closeParenthesisRegex + nonCapturingGroupClose +
-        nonCapturingGroupClose + '*' +
+        nonCapturingGroupClose +
         '\\s*$',
         'gm',
       );


### PR DESCRIPTION
Nodes should always have parenthesis

Avoids extra infos to be parsed as nodes

Fixes #228 