### PR TITLE
Node indexes

### DIFF
--- a/src/assets/scss/_plan-diagram.scss
+++ b/src/assets/scss/_plan-diagram.scss
@@ -4,7 +4,7 @@
     max-height: 30%;
   }
   // make sure diagram right column takes as much width as possible
-  table tr td:nth-child(2) {
+  table tr td:nth-child(3) {
     width: 90%;
   }
   font-family: $font-family-sans-serif;
@@ -31,6 +31,7 @@
     color: $text-color;
     white-space: nowrap;
 
+    &.node-index,
     &.node-type,
     &.subplan {
       font-size: $font-size-sm;

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -82,8 +82,8 @@
               :content="tooltip(row[1])"
               v-tippy="{arrow: true, animation: 'fade', delay: [200, 0]}"
               @click.prevent="eventBus.$emit('clicknode', row[1].nodeId)"
-              @mouseover="eventBus.$emit('mouseovernode', row[1].nodeId)"
-              @mouseout="eventBus.$emit('mouseoutnode', row[1].nodeId)"
+              @mouseenter="eventBus.$emit('mouseovernode', row[1].nodeId)"
+              @mouseleave="eventBus.$emit('mouseoutnode', row[1].nodeId)"
               >
 
               <td class="node-index">

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -78,12 +78,12 @@
             </tr>
             <tr
               class="no-focus-outline"
-              :class="{'highlight': row[1] === highlightedNode}"
+              :class="{'highlight': row[1].nodeId === highlightedNode}"
               :content="tooltip(row[1])"
               v-tippy="{arrow: true, animation: 'fade', delay: [200, 0]}"
-              @click.prevent="eventBus.$emit('clicknode', row[1])"
-              @mouseover="eventBus.$emit('mouseovernode', row[1])"
-              @mouseout="eventBus.$emit('mouseoutnode', row[1])"
+              @click.prevent="eventBus.$emit('clicknode', row[1].nodeId)"
+              @mouseover="eventBus.$emit('mouseovernode', row[1].nodeId)"
+              @mouseout="eventBus.$emit('mouseoutnode', row[1].nodeId)"
               >
 
               <td class="node-type pr-2">

--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -53,7 +53,7 @@
       <table class="my-1" v-if="dataAvailable">
         <tbody v-for="flat, index in plans">
           <tr v-if="index === 0 && plans.length > 1">
-            <th colspan="2" class="subplan">
+            <th colspan="3" class="subplan">
               Main Query Plan
             </th>
           </tr>
@@ -62,7 +62,7 @@
               <td
                 class="subplan pr-2"
                 :class="{'font-weight-bold': lodash.startsWith(row[1][nodeProps.SUBPLAN_NAME], 'CTE')}"
-                colspan="2"
+                colspan="3"
                 @click.prevent="eventBus.$emit('clickcte', row[1][nodeProps.SUBPLAN_NAME])"
                 >
                 <span class="tree-lines">
@@ -86,6 +86,11 @@
               @mouseout="eventBus.$emit('mouseoutnode', row[1].nodeId)"
               >
 
+              <td class="node-index">
+                <span class="small text-muted">
+                  #{{ row[1].nodeId }}
+                </span>
+              </td>
               <td class="node-type pr-2">
                 <span class="tree-lines">
                   <template v-for="i in lodash.range(row[0])">

--- a/src/components/Plan.vue
+++ b/src/components/Plan.vue
@@ -140,12 +140,20 @@
                 <pane ref="plan" class="plan d-flex flex-column flex-grow-1 grab-bing overflow-auto">
                   <ul class="main-plan p-2 mb-0">
                     <li>
-                      <plan-node :node="rootNode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root"/>
+                      <plan-node :node="rootNode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root">
+                        <template v-slot:nodelink="{ nodeIndex }">
+                          <slot name="nodelink" v-bind:nodeIndex="nodeIndex"></slot>
+                        </template>
+                      </plan-node>
                     </li>
                   </ul>
                   <ul class="init-plans p-2 mb-0" v-if="plan.ctes.length">
                     <li v-for="node in plan.ctes">
-                      <plan-node :node="node" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root"/>
+                      <plan-node :node="node" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root">
+                        <template v-slot:nodelink="{ nodeIndex }">
+                          <slot name="nodelink" v-bind:nodeIndex="nodeIndex"></slot>
+                        </template>
+                      </plan-node>
                     </li>
                   </ul>
                 </pane>

--- a/src/components/Plan.vue
+++ b/src/components/Plan.vue
@@ -141,8 +141,8 @@
                   <ul class="main-plan p-2 mb-0">
                     <li>
                       <plan-node :node="rootNode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root">
-                        <template v-slot:nodelink="{ node }">
-                          <slot name="nodelink" v-bind:node="node"></slot>
+                        <template v-slot:nodeindex="{ node }">
+                          <slot name="nodeindex" v-bind:node="node"></slot>
                         </template>
                       </plan-node>
                     </li>
@@ -150,8 +150,8 @@
                   <ul class="init-plans p-2 mb-0" v-if="plan.ctes.length">
                     <li v-for="node in plan.ctes">
                       <plan-node :node="node" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root">
-                        <template v-slot:nodelink="{ node }">
-                          <slot name="nodelink" v-bind:node="node"></slot>
+                        <template v-slot:nodeindex="{ node }">
+                          <slot name="nodeindex" v-bind:node="node"></slot>
                         </template>
                       </plan-node>
                     </li>

--- a/src/components/Plan.vue
+++ b/src/components/Plan.vue
@@ -141,8 +141,8 @@
                   <ul class="main-plan p-2 mb-0">
                     <li>
                       <plan-node :node="rootNode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root">
-                        <template v-slot:nodelink="{ nodeIndex }">
-                          <slot name="nodelink" v-bind:nodeIndex="nodeIndex"></slot>
+                        <template v-slot:nodelink="{ node }">
+                          <slot name="nodelink" v-bind:node="node"></slot>
                         </template>
                       </plan-node>
                     </li>
@@ -150,8 +150,8 @@
                   <ul class="init-plans p-2 mb-0" v-if="plan.ctes.length">
                     <li v-for="node in plan.ctes">
                       <plan-node :node="node" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus" ref="root">
-                        <template v-slot:nodelink="{ nodeIndex }">
-                          <slot name="nodelink" v-bind:nodeIndex="nodeIndex"></slot>
+                        <template v-slot:nodelink="{ node }">
+                          <slot name="nodelink" v-bind:node="node"></slot>
                         </template>
                       </plan-node>
                     </li>

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -10,8 +10,8 @@
         <i :class="['fa fa-fw', {'fa-compress': !collapsed, 'fa-expand': collapsed}]" v-on:click.stop="toggleCollapsed()" title="Collpase or expand child nodes"></i>
       </div>
       <div class="plan-node-body card"
-           @mouseover="eventBus.$emit('mouseovernode', node)"
-           @mouseout="eventBus.$emit('mouseoutnode', node)"
+           @mouseover="eventBus.$emit('mouseovernode', node.nodeId)"
+           @mouseout="eventBus.$emit('mouseoutnode', node.nodeId)"
       >
         <div class="card-body header no-focus-outline"
             v-on:click.stop="showDetails = !showDetails"
@@ -21,9 +21,9 @@
           <header class="mb-0">
             <h4>
               {{ getNodeName() }}
-              <slot name="nodelink" v-bind:nodeIndex="nodeIndex">
+              <slot name="nodelink" v-bind:nodeIndex="node.nodeId">
                 <span class="text-muted font-weight-normal small">
-                  #{{ nodeIndex }}
+                  #{{ node.nodeId }}
                 </span>
               </slot>
             </h4>
@@ -280,7 +280,7 @@
       <li v-for="subnode in plans">
         <plan-node :node="subnode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus">
           <template v-slot:nodelink="{ nodeIndex }">
-            <slot name="nodelink" v-bind:nodeIndex="nodeIndex"></slot>
+            <slot name="nodelink" v-bind:nodeIndex="node.nodeId"></slot>
           </template>
         </plan-node>
       </li>
@@ -398,6 +398,7 @@ export default class PlanNode extends Vue {
       NodeProp.WAL_RECORDS,
       NodeProp.WAL_BYTES,
       NodeProp.WAL_FPI,
+      NodeProp.NODE_ID,
   ];
 
   public setShowDetails(showDetails: boolean): void {
@@ -415,11 +416,6 @@ export default class PlanNode extends Vue {
 
     this.plannerRowEstimateDirection = this.node[NodeProp.PLANNER_ESTIMATE_DIRECTION];
     this.plannerRowEstimateValue = this.node[NodeProp.PLANNER_ESTIMATE_FACTOR];
-    this.plan.nodeComponents.push(this);
-  }
-
-  private destroyed(): void {
-    _.remove(this.plan.nodeComponents, (cmp) => cmp === this);
   }
 
   private calculateDuration() {
@@ -467,10 +463,6 @@ export default class PlanNode extends Vue {
 
   private getNodeTypeDescription() {
     return this.helpService.getNodeTypeDescription(this.node[NodeProp.NODE_TYPE]);
-  }
-
-  private get nodeIndex(): number {
-    return this.plan.nodeComponents.indexOf(this);
   }
 
   private getNodeName(): string {

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -21,7 +21,7 @@
           <header class="mb-0">
             <h4>
               {{ getNodeName() }}
-              <slot name="nodelink" v-bind:node="node">
+              <slot name="nodeindex" v-bind:node="node">
                 <span class="text-muted font-weight-normal small">
                   #{{ node.nodeId }}
                 </span>
@@ -279,8 +279,8 @@
     <ul v-if="plans" :class="['node-children', {'collapsed': collapsed}]">
       <li v-for="subnode in plans">
         <plan-node :node="subnode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus">
-          <template v-slot:nodelink="{ node }">
-            <slot name="nodelink" v-bind:node="node"></slot>
+          <template v-slot:nodeindex="{ node }">
+            <slot name="nodeindex" v-bind:node="node"></slot>
           </template>
         </plan-node>
       </li>

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -21,7 +21,7 @@
           <header class="mb-0">
             <h4>
               {{ getNodeName() }}
-              <slot name="nodelink" v-bind:nodeIndex="node.nodeId">
+              <slot name="nodelink" v-bind:node="node">
                 <span class="text-muted font-weight-normal small">
                   #{{ node.nodeId }}
                 </span>
@@ -279,8 +279,8 @@
     <ul v-if="plans" :class="['node-children', {'collapsed': collapsed}]">
       <li v-for="subnode in plans">
         <plan-node :node="subnode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus">
-          <template v-slot:nodelink="{ nodeIndex }">
-            <slot name="nodelink" v-bind:nodeIndex="node.nodeId"></slot>
+          <template v-slot:nodelink="{ node }">
+            <slot name="nodelink" v-bind:node="node"></slot>
           </template>
         </plan-node>
       </li>

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -58,7 +58,7 @@
             <div v-if="node[nodeProps.HASH_CONDITION]"><span class="text-muted">
                 on</span> {{node[nodeProps.HASH_CONDITION] | keysToString }}</div>
             <div v-if="node[nodeProps.CTE_NAME]">
-              <a class="text-reset" href v-on:click.prevent="eventBus.$emit('clickcte', 'CTE ' + node[nodeProps.CTE_NAME])">
+              <a class="text-reset" href v-on:click.stop.prevent="eventBus.$emit('clickcte', 'CTE ' + node[nodeProps.CTE_NAME])">
                 <i class="fa fa-link text-muted"></i>&nbsp;
                 <span class="text-muted">CTE</span> {{node[nodeProps.CTE_NAME]}}
               </a>

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -10,8 +10,8 @@
         <i :class="['fa fa-fw', {'fa-compress': !collapsed, 'fa-expand': collapsed}]" v-on:click.stop="toggleCollapsed()" title="Collpase or expand child nodes"></i>
       </div>
       <div class="plan-node-body card"
-           @mouseover="eventBus.$emit('mouseovernode', node.nodeId)"
-           @mouseout="eventBus.$emit('mouseoutnode', node.nodeId)"
+           @mouseenter="eventBus.$emit('mouseovernode', node.nodeId)"
+           @mouseleave="eventBus.$emit('mouseoutnode', node.nodeId)"
       >
         <div class="card-body header no-focus-outline"
             v-on:click.stop="showDetails = !showDetails"

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -21,7 +21,11 @@
           <header class="mb-0">
             <h4>
               {{ getNodeName() }}
-              <span class="text-muted font-weight-normal small">#{{ plan.nodeComponents.indexOf(currentCmp) }}</span>
+              <slot name="nodelink" v-bind:nodeIndex="nodeIndex">
+                <span class="text-muted font-weight-normal small">
+                  #{{ nodeIndex }}
+                </span>
+              </slot>
             </h4>
             <div class="float-right">
               <span v-if="durationClass" :class="'p-0  d-inline-block mb-0 ml-1 text-nowrap alert ' + durationClass" title="Slow"><i class="fa fa-fw fa-clock"></i></span>
@@ -274,7 +278,11 @@
     </div>
     <ul v-if="plans" :class="['node-children', {'collapsed': collapsed}]">
       <li v-for="subnode in plans">
-        <plan-node :node="subnode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus"/>
+        <plan-node :node="subnode" :plan="plan" :viewOptions="viewOptions" :eventBus="eventBus">
+          <template v-slot:nodelink="{ nodeIndex }">
+            <slot name="nodelink" v-bind:nodeIndex="nodeIndex"></slot>
+          </template>
+        </plan-node>
       </li>
     </ul>
   </div>
@@ -307,8 +315,6 @@ export default class PlanNode extends Vue {
   @Prop(Object) private plan!: any;
   @Prop(Object) private viewOptions!: any;
   @Prop() private eventBus!: InstanceType<typeof Vue>;
-
-  private currentCmp;
 
   // UI flags
   private showDetails: boolean = false;
@@ -410,7 +416,6 @@ export default class PlanNode extends Vue {
     this.plannerRowEstimateDirection = this.node[NodeProp.PLANNER_ESTIMATE_DIRECTION];
     this.plannerRowEstimateValue = this.node[NodeProp.PLANNER_ESTIMATE_FACTOR];
     this.plan.nodeComponents.push(this);
-    this.currentCmp = this;
   }
 
   private destroyed(): void {
@@ -462,6 +467,10 @@ export default class PlanNode extends Vue {
 
   private getNodeTypeDescription() {
     return this.helpService.getNodeTypeDescription(this.node[NodeProp.NODE_TYPE]);
+  }
+
+  private get nodeIndex(): number {
+    return this.plan.nodeComponents.indexOf(this);
   }
 
   private getNodeName(): string {

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -21,6 +21,7 @@
           <header class="mb-0">
             <h4>
               {{ getNodeName() }}
+              <span class="text-muted font-weight-normal small">#{{ plan.nodeComponents.indexOf(currentCmp) }}</span>
             </h4>
             <div class="float-right">
               <span v-if="durationClass" :class="'p-0  d-inline-block mb-0 ml-1 text-nowrap alert ' + durationClass" title="Slow"><i class="fa fa-fw fa-clock"></i></span>
@@ -307,6 +308,8 @@ export default class PlanNode extends Vue {
   @Prop(Object) private viewOptions!: any;
   @Prop() private eventBus!: InstanceType<typeof Vue>;
 
+  private currentCmp;
+
   // UI flags
   private showDetails: boolean = false;
   private collapsed: boolean = false;
@@ -391,6 +394,10 @@ export default class PlanNode extends Vue {
       NodeProp.WAL_FPI,
   ];
 
+  public setShowDetails(showDetails: boolean): void {
+    this.showDetails = showDetails;
+  }
+
   private created(): void {
     this.calculateProps();
     this.calculateBar();
@@ -403,6 +410,7 @@ export default class PlanNode extends Vue {
     this.plannerRowEstimateDirection = this.node[NodeProp.PLANNER_ESTIMATE_DIRECTION];
     this.plannerRowEstimateValue = this.node[NodeProp.PLANNER_ESTIMATE_FACTOR];
     this.plan.nodeComponents.push(this);
+    this.currentCmp = this;
   }
 
   private destroyed(): void {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -104,6 +104,7 @@ export enum NodeProp {
   WAL_FPI = 'WAL FPI',
 
   // computed by pev
+  NODE_ID = 'nodeId',
   EXCLUSIVE_DURATION = '*Duration (exclusive)',
   EXCLUSIVE_COST = '*Cost (exclusive)',
 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -50,8 +50,9 @@ export enum CenterMode {
 }
 
 export enum HighlightMode {
-  flash,
-  highlight,
+  flash = 1,
+  highlight = 2,
+  showdetails = 4,
 }
 
 export enum NodeProp {

--- a/src/iplan.ts
+++ b/src/iplan.ts
@@ -9,7 +9,6 @@ export interface IPlan {
   createdOn: Date;
   planStats: IPlanStats;
   formattedQuery?: string;
-  nodeComponents: PlanNode[];
   ctes: any[];
 }
 

--- a/src/services/help-service.ts
+++ b/src/services/help-service.ts
@@ -1,4 +1,6 @@
 export class HelpService {
+  public nodeId = 0;
+
   public getNodeTypeDescription(nodeType: string) {
     return NODE_DESCRIPTIONS[nodeType.toUpperCase()];
   }

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -9,6 +9,7 @@ import clarinet from 'clarinet';
 export class PlanService {
 
   private static instance: PlanService;
+  private nodeId: number = 0;
 
   public createPlan(planName: string, planContent: any, planQuery: string): IPlan {
     // remove any extra white spaces in the middle of query
@@ -25,10 +26,10 @@ export class PlanService {
       content: planContent,
       query: planQuery,
       planStats: {},
-      nodeComponents: [],
       ctes: [],
     };
 
+    this.nodeId = 0;
     this.processNode(plan.content.Plan, plan);
     this.calculateMaximums(plan.content);
     return plan;
@@ -41,6 +42,7 @@ export class PlanService {
 
   // recursively walk down the plan to compute various metrics
   public processNode(node: any, plan: any) {
+    node.nodeId = this.nodeId++;
     this.calculatePlannerEstimate(node);
 
     _.each(node[NodeProp.PLANS], (child) => {


### PR DESCRIPTION
With this PR, an index is given to each node and displayed on the main graph as well as in the diagram.

![Capture d’écran du 2020-10-29 09-10-10](https://user-images.githubusercontent.com/319774/97542183-9b9e6480-19c6-11eb-93ae-727eb41690f7.png)
![Capture d’écran du 2020-10-29 09-10-18](https://user-images.githubusercontent.com/319774/97542188-9ccf9180-19c6-11eb-9fb4-cd1e90cfc2df.png)


The way the node components are found has been reworked. We don't rely on an array of all components. Instead we loop recursively to PlanNode components. This improves performances a bit.

Using a slot it's even possible to modify the way the node index is displayed. This will be used for the dalibo's service to let users give a direct link to a given node.

If users want the plan chart to be automatically centered on a node the index (as integer) of a node can be provided using an optional `zoom-to` attribute.

```HTML
    <plan :plan-source="plan" :plan-query="query" :zoom-to="4" v-if="plan">
      <template v-slot:nodeindex="{ node }">
        <span class="text-danger">
          The node index is <b>{{ node.nodeId }}</b>
        </span>
      </template>                                                    
    </plan>
```