### PR TITLE
Make font size similar to plan nodes in main chart

### DIFF
--- a/src/assets/scss/_plan-diagram.scss
+++ b/src/assets/scss/_plan-diagram.scss
@@ -32,7 +32,7 @@
     &.node-index,
     &.node-type,
     &.subplan {
-      font-size: $font-size-sm;
+      font-size: $font-size-base;
     }
     &.node-type {
       text-transform: uppercase;


### PR DESCRIPTION
Prevents node indexes to be too small