### PR TITLE
Configure vue loader to preserve white space

### DIFF
--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -67,9 +67,8 @@
                 >
                 <span class="tree-lines">
                   <template v-for="i in lodash.range(row[0])">
-                    <template v-if="lodash.indexOf(row[3], i) != -1">│</template><template v-else-if="i !== 0">⠀</template>
-                  </template>
-                  <template v-if="index !== 0">{{ row[2] ? '└' : '├' }}</template>
+                    <template v-if="lodash.indexOf(row[3], i) != -1">│</template><template v-else-if="i !== 0">&nbsp;</template>
+                  </template><template v-if="index !== 0">{{ row[2] ? '└' : '├' }}</template>
                 </span>
                 <a class="font-italic text-reset"
                   href
@@ -94,12 +93,10 @@
               <td class="node-type pr-2">
                 <span class="tree-lines">
                   <template v-for="i in lodash.range(row[0])">
-                    <template v-if="lodash.indexOf(row[3], i) != -1">│</template><template v-else-if="i !== 0">⠀</template>
-                  </template>
-                  <template v-if="index !== 0">
-                    <template v-if="!row[1][nodeProps.SUBPLAN_NAME]">{{ row[2] ? '└' : '├' }}</template>
-                    <template v-else>
-                      <template v-if="!row[2]">│</template><template v-else>⠀</template>
+                    <template v-if="lodash.indexOf(row[3], i) != -1">│</template><template v-else-if="i !== 0">&nbsp;</template>
+                  </template><template v-if="index !== 0">
+                    <template v-if="!row[1][nodeProps.SUBPLAN_NAME]">{{ row[2] ? '└' : '├' }}</template><template v-else>
+                      <template v-if="!row[2]">│</template><template v-else>&nbsp;</template>
                     </template>
                   </template>
                 </span>

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -41,31 +41,27 @@
 
           <div v-if="viewOptions.viewMode === viewModes.FULL" class="text-left text-monospace">
             <div v-if="node[nodeProps.RELATION_NAME]" :class="{'line-clamp-2': !showDetails}">
-              <span class="text-muted">on </span>
-              <span v-if="node[nodeProps.SCHEMA]">{{node[nodeProps.SCHEMA]}}.</span>{{node[nodeProps.RELATION_NAME]}}
+              <span class="text-muted">on&nbsp;</span><span v-if="node[nodeProps.SCHEMA]">{{node[nodeProps.SCHEMA]}}.</span>{{node[nodeProps.RELATION_NAME]}}
               <span v-if="node[nodeProps.ALIAS]">
-                <span class="text-muted"> as</span>
+                <span class="text-muted">as</span>
                 {{node[nodeProps.ALIAS]}}
               </span>
             </div>
             <div v-if="node[nodeProps.GROUP_KEY]" :class="{'line-clamp-2': !showDetails}">
-              <span class="text-muted">by</span> <span v-html="$options.filters.keysToString(node[nodeProps.GROUP_KEY])"></span></div>
+              <span class="text-muted">by</span>&nbsp;<span v-html="$options.filters.keysToString(node[nodeProps.GROUP_KEY])"></span></div>
             <div v-if="node[nodeProps.SORT_KEY]" :class="{'line-clamp-2': !showDetails}">
               <span class="text-muted">by</span> <span v-html="$options.filters.sortKeys(node[nodeProps.SORT_KEY], node[nodeProps.PRESORTED_KEY])"></span>
             </div>
             <div v-if="node[nodeProps.JOIN_TYPE]">{{node[nodeProps.JOIN_TYPE] }}
               <span class="text-muted">join</span></div>
             <div v-if="node[nodeProps.INDEX_NAME]" :class="{'line-clamp-2': !showDetails}">
-              <span class="text-muted">using </span>
-              <span v-html="$options.filters.keysToString(node[nodeProps.INDEX_NAME])"></span>
+              <span class="text-muted">using</span>&nbsp;<span v-html="$options.filters.keysToString(node[nodeProps.INDEX_NAME])"></span>
             </div>
             <div v-if="node[nodeProps.HASH_CONDITION]" :class="{'line-clamp-2': !showDetails}">
-              <span class="text-muted">on </span>
-              <span v-html="$options.filters.keysToString(node[nodeProps.HASH_CONDITION])"></span></div>
+              <span class="text-muted">on</span>&nbsp;<span v-html="$options.filters.keysToString(node[nodeProps.HASH_CONDITION])"></span></div>
             <div v-if="node[nodeProps.CTE_NAME]">
               <a class="text-reset" href v-on:click.stop.prevent="eventBus.$emit('clickcte', 'CTE ' + node[nodeProps.CTE_NAME])">
-                <i class="fa fa-search text-muted"></i>&nbsp;
-                <span class="text-muted">CTE</span> {{node[nodeProps.CTE_NAME]}}
+                <i class="fa fa-search text-muted"></i>&nbsp;<span class="text-muted">CTE</span> {{node[nodeProps.CTE_NAME]}}
               </a>
             </div>
           </div>

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,6 +12,19 @@ module.exports = {
   css: {
     extract: false,
   },
+  chainWebpack: (config) => {
+    config.module
+      .rule("vue")
+      .use("vue-loader")
+      .loader("vue-loader")
+      .tap((options) => ({
+        ...options,
+        compilerOptions: {
+          ...options.compilerOptions,
+          whitespace: "preserve",
+        },
+      }));
+  },
   configureWebpack: {
     plugins: [
       // To strip all locales except “en”


### PR DESCRIPTION
And change templates to add more non breaking spaces

Prevents relation name, index name to be split after 'on' or 'using' keywords

Before:
![Capture d’écran du 2021-02-17 08-54-21](https://user-images.githubusercontent.com/319774/108172929-c2131780-70fd-11eb-8bbf-f3317d92e29b.png)
After:
![Capture d’écran du 2021-02-17 08-53-07](https://user-images.githubusercontent.com/319774/108172930-c3444480-70fd-11eb-8a93-c6349e2bc068.png)
