### PR TITLE
Revised row counts

### DIFF
--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -111,7 +111,7 @@
                   <div class="progress-bar border-left bg-secondary-light" role="progressbar" :style="'width: ' + (row[1][nodeProps.ACTUAL_TOTAL_TIME] - row[1][nodeProps.EXCLUSIVE_DURATION]) / (plan.planStats.executionTime || plan.content.Plan[nodeProps.ACTUAL_TOTAL_TIME]) * 100 + '%; height:5px;'" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100"></div>
                 </div>
                 <div class="progress rounded-0 align-items-center bg-transparent" style="height: 5px;" v-else-if="viewOptions.metric == metrics.rows">
-                  <div class="bg-secondary" role="progressbar" :style="'width: ' + Math.round(row[1][nodeProps.ACTUAL_ROWS] / plan.planStats.maxRows * 100) + '%'" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100" style="height: 5px;"></div>
+                  <div class="bg-secondary" role="progressbar" :style="'width: ' + Math.round(row[1][nodeProps.ACTUAL_ROWS_REVISED] / plan.planStats.maxRows * 100) + '%'" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100" style="height: 5px;"></div>
                 </div>
                 <div class="progress rounded-0 align-items-center bg-transparent justify-content-center" style="height: 10px;" v-if="viewOptions.metric == metrics.estimate_factor">
                   <span class="text-muted small">
@@ -277,7 +277,7 @@ export default class Diagram extends Vue {
   private rowsTooltip(node: Node): string {
     return [
       'Rows: ',
-      rows(node[NodeProp.ACTUAL_ROWS]),
+      rows(node[NodeProp.ACTUAL_ROWS_REVISED]),
     ].join('');
   }
 

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -414,6 +414,8 @@ export default class PlanNode extends Vue {
       NodeProp.WAL_BYTES,
       NodeProp.WAL_FPI,
       NodeProp.NODE_ID,
+      NodeProp.ROWS_REMOVED_BY_FILTER,
+      NodeProp.ROWS_REMOVED_BY_JOIN_FILTER,
   ];
 
   public setShowDetails(showDetails: boolean): void {

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -124,7 +124,7 @@
             </div>
             <div>
               <i class="fa fa-fw fa-align-justify text-muted"></i>
-              <b>Rows:</b> <span class="px-1">{{ formattedProp('ACTUAL_ROWS') }}</span> <span class="text-muted" v-if="node[nodeProps.PLAN_ROWS]">(Planned: {{ formattedProp('PLAN_ROWS') }})</span>
+              <b>Rows:</b> <span class="px-1">{{ tilde + formattedProp('ACTUAL_ROWS_REVISED') }}</span> <span class="text-muted" v-if="node[nodeProps.PLAN_ROWS]">(Planned: {{ tilde + formattedProp('PLAN_ROWS_REVISED') }})</span>
               <span v-if="plannerRowEstimateDirection !== estimateDirections.none && shouldShowPlannerEstimate">
                 |
                 <span v-if="plannerRowEstimateDirection === estimateDirections.over"><i class="fa fa-arrow-up"></i> over</span>
@@ -141,7 +141,7 @@
                 {{ nodeProps[rowsRemovedProp] }}:
               </b>
               <span>
-                <span class="px-1">{{ formattedProp(rowsRemovedProp) }}</span>|
+                <span class="px-1">{{ tilde + formattedProp(rowsRemovedProp) }}</span>|
                 <span :class="'p-0 px-1 alert ' + rowsRemovedClass">{{ rowsRemovedPercent == 100 ? '>99' : rowsRemovedPercent }}%</span>
               </span>
             </div>
@@ -416,6 +416,10 @@ export default class PlanNode extends Vue {
       NodeProp.NODE_ID,
       NodeProp.ROWS_REMOVED_BY_FILTER,
       NodeProp.ROWS_REMOVED_BY_JOIN_FILTER,
+      NodeProp.ACTUAL_ROWS_REVISED,
+      NodeProp.PLAN_ROWS_REVISED,
+      NodeProp.ROWS_REMOVED_BY_FILTER_REVISED,
+      NodeProp.ROWS_REMOVED_BY_JOIN_FILTER_REVISED,
   ];
 
   public setShowDetails(showDetails: boolean): void {
@@ -449,7 +453,7 @@ export default class PlanNode extends Vue {
 
   private get rowsRemovedProp() {
     const nodeKey = Object.keys(this.node).find(
-      (key) => key === NodeProp.ROWS_REMOVED_BY_FILTER || key === NodeProp.ROWS_REMOVED_BY_JOIN_FILTER,
+      (key) => key === NodeProp.ROWS_REMOVED_BY_FILTER_REVISED || key === NodeProp.ROWS_REMOVED_BY_JOIN_FILTER_REVISED,
     );
     type NodePropStrings = keyof typeof NodeProp;
     return Object.keys(NodeProp).find((prop) => NodeProp[prop as NodePropStrings] === nodeKey);

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -110,6 +110,10 @@ export enum NodeProp {
   NODE_ID = 'nodeId',
   EXCLUSIVE_DURATION = '*Duration (exclusive)',
   EXCLUSIVE_COST = '*Cost (exclusive)',
+  ACTUAL_ROWS_REVISED = '*Actual Rows Revised',
+  PLAN_ROWS_REVISED = '*Plan Rows Revised',
+  ROWS_REMOVED_BY_FILTER_REVISED = '*Rows Removed by Filter',
+  ROWS_REMOVED_BY_JOIN_FILTER_REVISED = '*Rows Removed by Join Filter',
 
   PLANNER_ESTIMATE_FACTOR = '*Planner Row Estimate Factor',
   PLANNER_ESTIMATE_DIRECTION = '*Planner Row Estimate Direction',
@@ -159,6 +163,8 @@ export const nodePropTypes: any = {};
 
 nodePropTypes[NodeProp.ACTUAL_ROWS] = PropType.rows;
 nodePropTypes[NodeProp.PLAN_ROWS] = PropType.rows;
+nodePropTypes[NodeProp.ACTUAL_ROWS_REVISED] = PropType.rows;
+nodePropTypes[NodeProp.PLAN_ROWS_REVISED] = PropType.rows;
 nodePropTypes[NodeProp.ACTUAL_TOTAL_TIME] = PropType.duration;
 nodePropTypes[NodeProp.ACTUAL_STARTUP_TIME] = PropType.duration;
 nodePropTypes[NodeProp.STARTUP_COST] = PropType.cost;
@@ -168,6 +174,8 @@ nodePropTypes[NodeProp.WORKERS] = PropType.json;
 nodePropTypes[NodeProp.SORT_SPACE_USED] = PropType.kilobytes;
 nodePropTypes[NodeProp.ROWS_REMOVED_BY_FILTER] = PropType.rows;
 nodePropTypes[NodeProp.ROWS_REMOVED_BY_JOIN_FILTER] = PropType.rows;
+nodePropTypes[NodeProp.ROWS_REMOVED_BY_FILTER_REVISED] = PropType.rows;
+nodePropTypes[NodeProp.ROWS_REMOVED_BY_JOIN_FILTER_REVISED] = PropType.rows;
 nodePropTypes[NodeProp.HEAP_FETCHES] = PropType.rows;
 nodePropTypes[NodeProp.OUTPUT] = PropType.list;
 nodePropTypes[NodeProp.SORT_KEY] = PropType.list;

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -174,6 +174,13 @@ export class PlanService {
     if (node[NodeProp.EXCLUSIVE_COST] < 0) {
       node[NodeProp.EXCLUSIVE_COST] = 0;
     }
+
+    _.each(['ACTUAL_ROWS', 'PLAN_ROWS', 'ROWS_REMOVED_BY_FILTER'], (prop: keyof typeof NodeProp) => {
+      if (!_.isUndefined(node[NodeProp[prop]])) {
+        const revisedProp = prop + '_REVISED' as keyof typeof NodeProp;
+        node[NodeProp[revisedProp]] = node[NodeProp[prop]] * node[NodeProp.ACTUAL_LOOPS];
+      }
+    });
   }
 
   // recursive function to get the sum of actual durations of a a node children


### PR DESCRIPTION
In https://github.com/dalibo/pev2/issues/98#issuecomment-615296354 I wrote that it was a bad idea to multiply the number of rows by the number of loops because it may not be accurate given the fact that the number of rows is an average value.

However I think that there are a lot of cases where the number of loops is not 1. Even if not completely accurate, it's in my opinion better to show number that better reflect reality.

In the following example, the number of loops for the Bitmap Index Scan is 25112. Each loop returns ~1 row. This means that the node itself returns ~25112 rows. In current master version, PEV2 does tell that only one row is returned.

```
Sort  (cost=148927.96..149012.78 rows=33927 width=49) (actual time=2906.084..2946.819 rows=24935 loops=1)
  Sort Key: ak.artikelnr_list
  Sort Method:  quicksort  Memory: 3536kB
  ->  Nested Loop  (cost=1.55..146374.93 rows=33927 width=49) (actual time=0.160..2531.059 rows=24935 loops=1)
        ->  Seq Scan on t_artikelkey ak  (cost=0.00..2312.30 rows=25130 width=237) (actual time=0.014..85.614 rows=25112 loops=1)
        ->  Bitmap Heap Scan on artikel_as aas  (cost=1.55..5.63 rows=6 width=10) (actual time=0.073..0.074 rows=1 loops=25112)
              Recheck Cond: ((aas.artikelnrforvererbung)::text = ANY ((ARRAY[ak.keysum1, ak.keysum2, ak.keysum3, ak.keysum4, ak.keysum5, ak.keysum6])::text[]))
              Filter: ((aas.aas_ask)::text = PRE::text)
              ->  Bitmap Index Scan on idx_artikel_as_artnrver  (cost=0.00..1.55 rows=6 width=0) (actual time=0.066..0.066 rows=1 loops=25112)
                    Index Cond: ((aas.artikelnrforvererbung)::text = ANY ((ARRAY[ak.keysum1, ak.keysum2, ak.keysum3, ak.keysum4, ak.keysum5, ak.keysum6])::text[]))
```
Currently, here's what's displayed:
![Capture d’écran du 2021-02-17 11-30-11](https://user-images.githubusercontent.com/319774/108191537-87b47500-7113-11eb-903d-22d11f4ba8cf.png)
![Capture d’écran du 2021-02-17 11-27-40](https://user-images.githubusercontent.com/319774/108191228-31dfcd00-7113-11eb-94cb-7043866d4edc.png)

With the current PR:
![Capture d’écran du 2021-02-17 11-29-11](https://user-images.githubusercontent.com/319774/108191427-66ec1f80-7113-11eb-87a8-722f540cb14b.png)
![Capture d’écran du 2021-02-17 11-29-21](https://user-images.githubusercontent.com/319774/108191435-68b5e300-7113-11eb-8a74-bb0323d4962b.png)
