### PR TITLE
Correctly parse nodes of 'Tid * Scan' type

### DIFF
--- a/src/inode.ts
+++ b/src/inode.ts
@@ -5,7 +5,7 @@ export default class Node {
   constructor(type: string) {
     this[NodeProp.NODE_TYPE] = type;
     // tslint:disable-next-line:max-line-length
-    const scanMatches = /^((?:Parallel\s+)?(?:Seq\sScan|Tid\sScan|Bitmap\s+Heap\s+Scan|Foreign\s+Scan|Update|Insert|Delete))\son\s(\S+)(?:\s+(\S+))?$/.exec(type);
+    const scanMatches = /^((?:Parallel\s+)?(?:Seq\sScan|Tid.*Scan|Bitmap\s+Heap\s+Scan|Foreign\s+Scan|Update|Insert|Delete))\son\s(\S+)(?:\s+(\S+))?$/.exec(type);
     const bitmapMatches = /^(Bitmap\s+Index\s+Scan)\son\s(\S+)$/.exec(type);
     // tslint:disable-next-line:max-line-length
     const indexMatches = /^((?:Parallel\s+)?Index(?:\sOnly)?\sScan(?:\sBackward)?)\susing\s(\S+)\son\s(\S+)(?:\s+(\S+))?$/.exec(type);

--- a/src/services/__tests__/from-text/34-expect
+++ b/src/services/__tests__/from-text/34-expect
@@ -1,0 +1,21 @@
+{
+  "Plan": {
+    "Node Type": "Tid Range Scan",
+    "Relation Name": "test",
+    "Startup Cost": 0,
+    "Total Cost": 142.05,
+    "Plan Rows": 9605,
+    "Plan Width": 4,
+    "Actual Startup Time": 0.019,
+    "Actual Total Time": 2.116,
+    "Actual Rows": 9600,
+    "Actual Loops": 1,
+    "TID Cond": "(ctid > '(400,0)'::tid)",
+    "Shared Hit Blocks": 43,
+    "Shared Read Blocks": 0,
+    "Shared Written Blocks": 0,
+    "Shared Dirtied Blocks": 0
+  },
+  "Planning Time": 0.079,
+  "Execution Time": 3.372
+}

--- a/src/services/__tests__/from-text/34-plan
+++ b/src/services/__tests__/from-text/34-plan
@@ -1,0 +1,8 @@
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Tid Range Scan on test  (cost=0.00..142.05 rows=9605 width=4) (actual time=0.019..2.116 rows=9600 loops=1)
+   TID Cond: (ctid > '(400,0)'::tid)
+   Buffers: shared hit=43
+ Planning Time: 0.079 ms
+ Execution Time: 3.372 ms
+(5 rows)


### PR DESCRIPTION
Fixes #379