### PR TITLE
Parse if there are comas in settings values

### DIFF
--- a/src/services/__tests__/from-text/36-expect
+++ b/src/services/__tests__/from-text/36-expect
@@ -1,0 +1,13 @@
+{
+     "Plan": {
+         "Node Type": "Result",
+         "Startup Cost": 0,
+         "Total Cost": 0.01,
+         "Plan Rows": 1,
+         "Plan Width": 4
+     },
+     "Settings": {
+         "search_path": "public, magasin",
+         "work_mem": "8MB"
+     }
+}

--- a/src/services/__tests__/from-text/36-plan
+++ b/src/services/__tests__/from-text/36-plan
@@ -1,0 +1,4 @@
+QUERY PLAN                          
+-------------------------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=4)
+ Settings: search_path = 'public, magasin', work_mem = '8MB'

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -935,11 +935,11 @@ export class PlanService {
 
     if (settingsMatches) {
       el.Settings = {};
-      const settings = settingsMatches[2].split(/\s*,\s*/);
+      const settings = splitBalanced(settingsMatches[2], ',');
       let matches;
       _.each(settings, (option) => {
         const reg = /^(\S*)\s+=\s+(.*)$/g;
-        matches = reg.exec(option);
+        matches = reg.exec(_.trim(option));
         el.Settings[matches![1]] = matches![2].replace(/'/g, '');
       });
       return true;


### PR DESCRIPTION
Use splitBalanced to make sure that the settings are split with comas that are not in matching/balanced parenthesis or quotes

Fixes #433