### PR TITLE
Explicitely export style.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ".": {
       "import": "./dist/pev2.es.js",
       "require": "./dist/pev2.umd.js"
-    }
+    },
+    "./dist/style.css": "./dist/style.css"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Required to prevent the following error when using vite:
Missing "./dist/style.css" export in "pev2" package