### PR TITLE
Don't let highlight.js manage the overflow

### DIFF
--- a/src/components/Plan.vue
+++ b/src/components/Plan.vue
@@ -895,7 +895,7 @@ function isNeverExecuted(node: Node): boolean {
           <div class="overflow-auto flex-grow-1">
             <pre
               class="small p-2 mb-0"
-            ><code class="hljs" v-html="json_(planSource)"></code></pre>
+            ><code v-html="json_(planSource)"></code></pre>
           </div>
           <copy :content="planSource" />
         </div>
@@ -909,7 +909,7 @@ function isNeverExecuted(node: Node): boolean {
           <div class="overflow-auto flex-grow-1">
             <pre
               class="small p-2 mb-0"
-            ><code class="hljs" v-html="pgsql_(queryText)"></code></pre>
+            ><code v-html="pgsql_(queryText)"></code></pre>
           </div>
         </div>
         <copy :content="queryText" />


### PR DESCRIPTION
With the addition of hljs class in <code> an overflow-x: auto was automatically added.
It was prevently horizontal scrollbar to be visible properly.See g0744ce0.