### PR TITLE
De-duplicate double quotes in JSON plans

### DIFF
--- a/src/services/__tests__/09-plan-json-double-doule-quotes.spec.ts
+++ b/src/services/__tests__/09-plan-json-double-doule-quotes.spec.ts
@@ -1,0 +1,47 @@
+import { PlanService } from "@/services/plan-service"
+import type { IPlanContent } from "@/interfaces"
+
+describe("PlanService", () => {
+  test("correctly handles two double quotes in JSON", () => {
+    const planService = new PlanService()
+    const source = `
+"[
+  {
+    ""Plan"": {
+      ""Node Type"": ""ModifyTable"",
+      ""Operation"": ""Delete"",
+      ""Parallel Aware"": false,
+      ""Async Capable"": false,
+      ""Relation Name"": ""toto123456789"",
+      ""Schema"": ""public"",
+      ""Alias"": ""toto123456789"",
+      ""Startup Cost"": 0.00,
+      ""Total Cost"": 72124.00,
+      ""Plan Rows"": 0,
+      ""Plan Width"": 0,
+      ""Plans"": [
+        {
+          ""Node Type"": ""Seq Scan"",
+          ""Parent Relationship"": ""Outer"",
+          ""Parallel Aware"": false,
+          ""Async Capable"": false,
+          ""Relation Name"": ""toto123456789"",
+          ""Schema"": ""public"",
+          ""Alias"": ""toto123456789"",
+          ""Startup Cost"": 0.00,
+          ""Total Cost"": 72124.00,
+          ""Plan Rows"": 5000000,
+          ""Plan Width"": 6,
+          ""Output"": [""ctid""]
+        }
+      ]
+    },
+    ""Settings"": {
+    },
+    ""Planning Time"": 0.041
+  }
+]"
+`
+    planService.fromJson(source) as unknown as IPlanContent
+  })
+})

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -361,6 +361,8 @@ export class PlanService {
     const useSource: string = sourceLines
       .slice(firstLineIndex, lastLineIndex + 1)
       .join("\n")
+      // Replace two double quotes (added by pgAdmin)
+      .replace(/""/gm, '"')
 
     return this.parseJson(useSource)
   }


### PR DESCRIPTION
This weird format is generated by pgAdmin apparently.

Fixes #539