### PR TITLE
Don't fail parsing wrapped lines

### DIFF
--- a/src/services/__tests__/12-line-wrapped-plans/10-expect
+++ b/src/services/__tests__/12-line-wrapped-plans/10-expect
@@ -1,0 +1,56 @@
+{
+  "Plan": {
+    "Actual Loops": 1,
+    "Actual Rows": 34956,
+    "Actual Startup Time": 0.025,
+    "Actual Total Time": 10.198,
+    "Node Type": "Nested Loop",
+    "Plans": [
+      {
+        "Actual Loops": 1,
+        "Actual Rows": 402,
+        "Actual Startup Time": 0.013,
+        "Actual Total Time": 0.058,
+        "Node Type": "Seq Scan",
+        "Plan Rows": 402,
+        "Total Cost": 6.02,
+        "Relation Name": "t1",
+        "Startup Cost": 0,
+        "Plan Width": 4
+      },
+      {
+        "Actual Loops": 402,
+        "Actual Rows": 100,
+        "Actual Startup Time": 0,
+        "Actual Total Time": 0.008,
+        "Node Type": "Materialize",
+        "Plans": [
+          {
+            "Actual Loops": 1,
+            "Actual Rows": 100,
+            "Actual Startup Time": 0.005,
+            "Actual Total Time": 0.015,
+            "Node Type": "Seq Scan",
+            "Plan Rows": 100,
+            "Total Cost": 2,
+            "Relation Name": "t2",
+            "Startup Cost": 0,
+            "Plan Width": 4
+          }
+        ],
+        "Plan Rows": 100,
+        "Total Cost": 2.5,
+        "Startup Cost": 0,
+        "Plan Width": 4
+      }
+    ],
+    "Plan Rows": 13400,
+    "Total Cost": 611.27,
+    "Startup Cost": 0,
+    "Plan Width": 8,
+    "Join Filter": "(t1.c1 > t2.c2)",
+    "Rows Removed by Join Filter": 5244
+  },
+  "Planning Time": 0.083,
+  "Execution Time": 12.035
+}

--- a/src/services/__tests__/12-line-wrapped-plans/10-plan
+++ b/src/services/__tests__/12-line-wrapped-plans/10-plan
@@ -1,0 +1,9 @@
+ Nested Loop  (cost=0.00..611.27 rows=13400 width=8) (actual time=0.025..10.198 rows=34956 loops=1)
+   Join Filter: (t1.c1 >
+ t2.c2)
+   Rows Removed by Join Filter: 5244
+   ->  Seq Scan on t1  (cost=0.00..6.02 rows=402 width=4) (actual time=0.013..0.058 rows=402 loops=1)
+   ->  Materialize  (cost=0.00..2.50 rows=100 width=4) (actual time=0.000..0.008 rows=100 loops=402)
+         ->  Seq Scan on t2  (cost=0.00..2.00 rows=100 width=4) (actual time=0.005..0.015 rows=100 loops=1)
+ Planning Time: 0.083 ms
+ Execution Time: 12.035 ms

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -439,6 +439,11 @@ export class PlanService {
     const out: string[] = []
     const lines = text.split(/\r?\n/)
     const countChar = (str: string, ch: RegExp) => (str.match(ch) || []).length
+    const closingFirst = (str: string) => {
+      const closingParIndex = str.indexOf(")")
+      const openingParIndex = str.indexOf("(")
+      return closingParIndex != -1 && closingParIndex < openingParIndex
+    }
 
     _.each(lines, (line: string) => {
       if (countChar(line, /\)/g) > countChar(line, /\(/g)) {
@@ -453,7 +458,8 @@ export class PlanService {
         out.push(line)
       } else if (
         line.match(/^\S/) || // doesn't start with a blank space (allowed only for the first node)
-        line.match(/^\s*\(/) // first non-blank character is an opening parenthesis
+        line.match(/^\s*\(/) || // first non-blank character is an opening parenthesis
+        closingFirst(line) // closing parenthesis before opening one
       ) {
         if (0 < out.length) {
           out[out.length - 1] += line


### PR DESCRIPTION
Fixes #546

We now take into account lines that start with a blank space but the first parenthesis is a closing one.
Ex :
        Join Filter: (otp.numrole =
 311)