### PR TITLE
Stop mousewheel event on output tab body

### DIFF
--- a/src/components/PlanNodeDetail.vue
+++ b/src/components/PlanNodeDetail.vue
@@ -493,6 +493,7 @@ watch(activeTab, () => {
       :class="{ 'show active': activeTab === 'output' }"
       v-html="formattedProp('OUTPUT')"
       style="max-height: 200px"
+      @mousewheel.stop
     ></div>
     <div
       class="tab-pane"


### PR DESCRIPTION
This prevents zooming in/out the chart when there's an scrollbar for this tab content.