### PR TITLE
Only create release drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,6 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: dist-app/index.html
+        # To only send out release mails when the release 
+        # notes have been manually added
+        draft: true


### PR DESCRIPTION
Release mails (Watch -> Custom -> Releases) are sent out when a release is created. Unfortunately, when the release notes are not yet added, the mail is mostly useless. 

After this change, the release is created in draft and after editing it, it needs to be published (one click, similar to save). With this workflow, the release email now contains the release notes.