### PR TITLE
Parse global info lines with depth 1

### DIFF
--- a/src/services/__tests__/from-text/39-expect
+++ b/src/services/__tests__/from-text/39-expect
@@ -1,0 +1,12 @@
+{
+  "Plan": {
+    "Node Type": "Nested Loop Join",
+    "Plans": [{
+      "Node Type": "Bitmap Heap Scan",
+      "Plans": [{
+        "Node Type": "Bitmap Index Scan"
+      }]
+    }]
+  },
+  "Execution Time": 9762.684
+}

--- a/src/services/__tests__/from-text/39-plan
+++ b/src/services/__tests__/from-text/39-plan
@@ -1,0 +1,5 @@
+Nested Loop Left Join  (cost=11.95..28.52 rows=5 width=157)
+   ->  Bitmap Heap Scan on public.rel_users_exams  (cost=11.80..20.27 rows=5 width=52)
+         Output: rel_users_exams.user_username, rel_users_exams.exam_id
+         ->  Bitmap Index Scan on rel_users_exams_pkey  (cost=0.00..11.80 rows=5 width=0)
+ Execution Time: 9762.684 ms

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -834,7 +834,10 @@ export class PlanService {
         //const prefix = extraMatches[1]
 
         // Remove elements from elementsAtDepth for deeper levels
-        _.remove(elementsAtDepth, (e) => e[0] >= depth)
+        // Depth == 1 is a special case here. Global info (for example
+        // execution|planning time) have a depth of 1 but shouldn't be removed
+        // in case first node was at depth 0.
+        _.remove(elementsAtDepth, (e) => e[0] >= depth || depth == 1)
 
         let element
         if (elementsAtDepth.length === 0) {


### PR DESCRIPTION
The Execution|Planning time lines are not parsed correctly when the identation (usually 1 blank space) is not the same as the first node of the plan. It may happen for example when a leading blank space is removed from first line.