### PR TITLE
#626 The diagram view includes 'Parallel' for parallel-aware nodes

### DIFF
--- a/src/components/DiagramRow.vue
+++ b/src/components/DiagramRow.vue
@@ -46,6 +46,7 @@ const {
   estimateFactorPercent,
   estimateFactorTooltip,
   ioTooltip,
+  nodeName,
   rowsTooltip,
   timeTooltip,
 } = useNode(plan, node, viewOptions)
@@ -117,7 +118,7 @@ watch(
         :index="index"
         dense
       ></level-divider>
-      {{ node[NodeProp.NODE_TYPE] }}
+      {{ nodeName }}
     </td>
     <td>
       <!-- time -->


### PR DESCRIPTION
Per #626, the Diagram doesn't include `Parallel` for parallel-aware nodes (Seq Scan, Append, Hash, etc).  The 'Parallel' modifier is [stripped during parsing](https://github.com/dalibo/pev2/blob/4c53fa124aa43597665a0f8fe53d522239dfe7a0/src/interfaces.ts#L184) and then [added back in the graph view](https://github.com/dalibo/pev2/blob/4c53fa124aa43597665a0f8fe53d522239dfe7a0/src/node.ts#L89).

This PR re-uses the `nodeName` function to make the two match.

Render of `src/services/__tests__/12-line-wrapped-plans/05-plan`
![Screenshot_2024-03-21_at_11_31_22](https://github.com/dalibo/pev2/assets/36970459/5c13895c-ba12-4509-b162-290ffb665208)

I considered removing the line that strips out 'Parallel'.  But that would alter the `NODE_TYPE` and it's not clear to me whether nodes of the same type are handled separately (i.e. do all 'Seq Scans' need to be treated alike, regardless of whether they're parallel?)

## Test Plan
Existing tests pass, and lints cleanly (except for one lint that is not modified by this PR.)

I'd love to write a test for this change, but I don't see existing examples that test the view, just the parser. Please point me in the right direction if there's a good way to test the view.