### PR TITLE
Fix parsing issue for last line if contains quote

### DIFF
--- a/src/services/__tests__/16-quote-last-line.spec.ts
+++ b/src/services/__tests__/16-quote-last-line.spec.ts
@@ -1,0 +1,45 @@
+import { PlanService } from "@/services/plan-service"
+import type { IPlanContent } from "@/interfaces"
+
+describe("PlanService", () => {
+  test("Parses 'Execution time line", () => {
+    const planService = new PlanService()
+
+    // tslint:disable:max-line-length
+    const source = `
+"Aggregate  (cost=24729994.62..24729994.63 rows=1 width=8) (actual time=126922.755..126980.072 rows=1 loops=1)"
+"  Buffers: shared hit=31033317 read=640327, temp read=271916 written=271928"
+"Planning:"
+"  Buffers: shared hit=227 read=9"
+"Planning Time: 14.620 ms"
+"JIT:"
+"  Functions: 829"
+"  Options: Inlining true, Optimization true, Expressions true, Deforming true"
+"  Timing: Generation 113.965 ms, Inlining 706.405 ms, Optimization 7838.603 ms, Emission 7380.843 ms, Total 16039.815 ms"
+"Execution Time: 127241.780 ms"`
+
+    const plan = planService.fromSource(source) as IPlanContent
+    expect(plan?.["Execution Time"]).toEqual(127241.78)
+  })
+  test("Parses 'Execution time line", () => {
+    // Same plan but with a line break at the end
+    const planService = new PlanService()
+
+    // tslint:disable:max-line-length
+    const source = `
+"Aggregate  (cost=24729994.62..24729994.63 rows=1 width=8) (actual time=126922.755..126980.072 rows=1 loops=1)"
+"  Buffers: shared hit=31033317 read=640327, temp read=271916 written=271928"
+"Planning:"
+"  Buffers: shared hit=227 read=9"
+"Planning Time: 14.620 ms"
+"JIT:"
+"  Functions: 829"
+"  Options: Inlining true, Optimization true, Expressions true, Deforming true"
+"  Timing: Generation 113.965 ms, Inlining 706.405 ms, Optimization 7838.603 ms, Emission 7380.843 ms, Total 16039.815 ms"
+"Execution Time: 127241.780 ms"
+`
+
+    const plan = planService.fromSource(source) as IPlanContent
+    expect(plan?.["Execution Time"]).toEqual(127241.78)
+  })
+})

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -323,7 +323,7 @@ export class PlanService {
     source = source.replace(/^╔(═)+╗\r?\n/gm, "")
 
     // Remove quotes around lines, both ' and "
-    source = source.replace(/^(["'])(.*)\1\r?\n/gm, "$2\n")
+    source = source.replace(/^(["'])(.*)\1\r?/gm, "$2\n")
 
     // Remove "+" line continuations
     source = source.replace(/\s*\+\r?\n/g, "\n")


### PR DESCRIPTION
For example, the "Execution time" line was not parsed correctly when surrounded by quotes and on the very last line (no line break after)

Fixes #573
Fixes #601