### PR TITLE
Put first threshold level at 0 for heap fetches

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -213,7 +213,7 @@ export default function useNode(
       c = 4
     } else if (i > 40) {
       c = 3
-    } else if (i > 10) {
+    } else if (i > 0) {
       c = 2
     }
     if (c) {


### PR DESCRIPTION
This helps highlighting heap fetches when there's only a few, which can already have significant impact on performance.

See #589