### PR TITLE
Make Aggregate nodes more consistent in TEXT and JSON

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -96,6 +96,7 @@ export enum NodeProp {
   PRE_SORTED_GROUPS = "Pre-sorted Groups",
   PRESORTED_KEY = "Presorted Key",
   FILTER = "Filter",
+  STRATEGY = "Strategy",
 
   // computed by pev
   NODE_ID = "nodeId",

--- a/src/services/help-service.ts
+++ b/src/services/help-service.ts
@@ -358,6 +358,7 @@ const notMiscProperties: string[] = [
   NodeProp.RELATION_NAME,
   NodeProp.ALIAS,
   NodeProp.FUNCTION_NAME,
+  NodeProp.STRATEGY,
 ]
 
 export function shouldShowProp(key: string, value: unknown): boolean {

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -103,6 +103,7 @@ export class PlanService {
     this.calculateActuals(node)
     this.calculateExclusives(node)
     this.calculateIoTimingsAverage(node)
+    this.convertNodeType(node)
   }
 
   public calculateMaximums(plan: IPlan) {
@@ -1240,5 +1241,26 @@ export class PlanService {
     return _.some(children, (child) => {
       return _.has(child, NodeProp.OUTPUT) || this.findOutputProperty(child)
     })
+  }
+
+  private convertNodeType(node: Node): void {
+    // Convert some node type (possibly from JSON source) to match the TEXT format
+    if (node[NodeProp.NODE_TYPE] == "Aggregate") {
+      let prefix = ""
+      switch (node[NodeProp.STRATEGY]) {
+        case "Sorted":
+          prefix = "Group"
+          break
+        case "Hashed":
+          prefix = "Hash"
+          break
+        case "Plain":
+          prefix = ""
+          break
+        default:
+          console.error("Unsupported Aggregate Strategy")
+      }
+      node[NodeProp.NODE_TYPE] = prefix + "Aggregate"
+    }
   }
 }


### PR DESCRIPTION
JSON has a "Strategy" key to distinguish aggregate types. Here we convert this to what the TEXT format uses.

Fixes #495