### PR TITLE
Don't add extra empty line when cleaning up quotes

### DIFF
--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -323,7 +323,7 @@ export class PlanService {
     source = source.replace(/^╔(═)+╗\r?\n/gm, "")
 
     // Remove quotes around lines, both ' and "
-    source = source.replace(/^(["'])(.*)\1\r?/gm, "$2\n")
+    source = source.replace(/^(["'])(.*)\1\r?/gm, "$2")
 
     // Remove "+" line continuations
     source = source.replace(/\s*\+\r?\n/g, "\n")


### PR DESCRIPTION
The modified source was having extra blank lines.