### PR TITLE
Don't try to convert Aggregate node without Strategy

### DIFF
--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -1245,7 +1245,7 @@ export class PlanService {
 
   private convertNodeType(node: Node): void {
     // Convert some node type (possibly from JSON source) to match the TEXT format
-    if (node[NodeProp.NODE_TYPE] == "Aggregate") {
+    if (node[NodeProp.NODE_TYPE] == "Aggregate" && node[NodeProp.STRATEGY]) {
       let prefix = ""
       switch (node[NodeProp.STRATEGY]) {
         case "Sorted":


### PR DESCRIPTION
If Strategy property is present this means that it comes from JSON. Without this prop, the node doesn't need to be converted.