### PR TITLE
Fix parsing when Output is followed by lower-level node

### DIFF
--- a/src/services/__tests__/from-text/38-expect
+++ b/src/services/__tests__/from-text/38-expect
@@ -6,6 +6,13 @@
       "Plans": [{
         "Node Type": "Bitmap Index Scan"
       }]
+    }, {
+      "Node Type": "Sort",
+      "Plans": [{
+        "Node Type": "Seq Scan"
+      }]
+    }, {
+      "Node Type": "Sort"
     }]
   }
 }

--- a/src/services/__tests__/from-text/38-plan
+++ b/src/services/__tests__/from-text/38-plan
@@ -1,8 +1,13 @@
 Not a real plan. Showing how line breaks (with empty space at the begining) in an Output can break parsing.
+Also parsing shouldn't break if Output is followed by new node at a lower level.
                                                                     QUERY PLAN                                                                     
 ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
- Nested Loop Left Join  (cost=11.95..28.52 rows=5 width=157)
-   ->  Bitmap Heap Scan on public.rel_users_exams  (cost=11.80..20.27 rows=5 width=52)
-         Output: rel_users_exams.user_username, rel_users_exams.exam_id,
- rel_users_exams.started_at, rel_users_exams.finished_at
-         ->  Bitmap Index Scan on rel_users_exams_pkey  (cost=0.00..11.80 rows=5 width=0)
+ Nested Loop Left Join  (cost=0.00..0.00 rows=1 width=1)
+   ->  Bitmap Heap Scan on a  (cost=0.00..0.00 rows=1 width=1)
+         Output: blah,
+ dude 
+         ->  Bitmap Index Scan on rel_users_exams_pkey  (cost=0.00..0.00 rows=1 width=0)
+   ->  Sort  (cost=0.00..0.00 rows=1 width=1)
+         ->  Seq Scan on a  (cost=0.00..0.00 rows=1 width=1)
+               Output: a1
+   ->  Sort  (cost=0.00..0.00 rows=1 width=1)

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -504,7 +504,8 @@ export class PlanService {
       } else if (
         0 < out.length &&
         out[out.length - 1].match(/^\s*Output/i) &&
-        !sameIndent(out[out.length - 1], line)
+        !sameIndent(out[out.length - 1], line) &&
+        !line.match(/^\s*->/i)
       ) {
         // If previous line was Output and current line is not same indent
         // (which would mean a new information line)


### PR DESCRIPTION
Follow up for f1aa477b

Fixes #705