### PR TITLE
Update README to provide full size integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ open it in your favorite internet browser.
 />
 <link rel="stylesheet" href="https://unpkg.com/pev2/dist/pev2.css" />
 
-<div id="app">
+<div id="app" class="d-flex flex-column vh-100">
   <pev2 :plan-source="plan" plan-query="" />
 </div>
 


### PR DESCRIPTION
Add the HTML classes for the integration to use all the available height.

On Firefox 138. It took me a bit of time to find it so I believe it might be useful.

Before:

![image](https://github.com/user-attachments/assets/162dd526-6f78-44c3-a178-9e2e82eded18)

After:

![image](https://github.com/user-attachments/assets/0c7f4911-dcdd-4098-ae27-7965186e39e4)
