### PR TITLE
Don't rely on timing for ratio of rows removed warning

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -190,12 +190,10 @@ export default function useNode(
 
   const rowsRemovedClass = computed(() => {
     let c
-    // high percent of rows removed is relevant only when duration is high
-    // as well
-    const i = rowsRemovedPercent.value * executionTimePercent.value
-    if (i > 2000) {
+    const i = rowsRemovedPercent.value
+    if (i > 90) {
       c = 4
-    } else if (i > 500) {
+    } else if (i > 50) {
       c = 3
     }
     if (c) {


### PR DESCRIPTION
The color class to be used for rows removed isn't calculated using the execution time anymore since this may happen a lot of time for the same table in the same plan.