### PR TITLE
Drop unused "instance" private property of PlanService

### DIFF
--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -31,7 +31,6 @@ interface JitElement {
 type recurseItemType = Array<[Node, recurseItemType]>
 
 export class PlanService {
-  private static instance: PlanService
   private nodeId = 0
   private flat: Node[] = []
 


### PR DESCRIPTION
Typescript warns that the value is never used.