### PR TITLE
Fix TS7016: Could not find a declaration file for module 'pev2'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/pev2.es.js",
-      "require": "./dist/pev2.umd.js"
+      "require": "./dist/pev2.umd.js",
+      "types": "./dist/components/index.d.ts"
     },
     "./dist/pev2.css": "./dist/pev2.css"
   },


### PR DESCRIPTION
Continuation of #753
https://github.com/microsoft/TypeScript/issues/52363
```
TS7016: Could not find a declaration file for module 'pev2'. 'node_modules/pev2/dist/pev2.es.js' implicitly has an 'any' type.
  There are types at 'node_modules/pev2/dist/components/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'pev2' library may need to update its package.json or typings.
```