### PR TITLE
Include Join Type in node name

### DIFF
--- a/src/components/GridRow.vue
+++ b/src/components/GridRow.vue
@@ -390,10 +390,6 @@ const showDetails = ref<boolean>(false)
               "
             ></span>
           </template>
-          <template v-if="node[NodeProp.JOIN_TYPE]">
-            {{ node[NodeProp.JOIN_TYPE] }}
-            <span class="text-secondary">join</span>
-          </template>
           <template v-if="node[NodeProp.INDEX_NAME]">
             <span class="text-secondary">using</span>
             <span

--- a/src/components/PlanNode.vue
+++ b/src/components/PlanNode.vue
@@ -218,10 +218,6 @@ function centerCte() {
                 "
               ></span>
             </div>
-            <div v-if="node[NodeProp.JOIN_TYPE]">
-              {{ node[NodeProp.JOIN_TYPE] }}
-              <span class="text-secondary">join</span>
-            </div>
             <div
               v-if="node[NodeProp.INDEX_NAME]"
               :class="{ 'line-clamp-2': !showDetails }"

--- a/src/node.ts
+++ b/src/node.ts
@@ -97,6 +97,9 @@ export default function useNode(
     ) {
       nodeName += " " + node[NodeProp.SCAN_DIRECTION]
     }
+    if (node[NodeProp.JOIN_TYPE]) {
+      nodeName = nodeName.replace("Join", `${node[NodeProp.JOIN_TYPE]} Join`);
+    }
     return nodeName
   })
 


### PR DESCRIPTION
In the case of JSON formation, the join type (Left/Right) wasn't visible in the node name whereas for text format it was.

The node name now includes the join type.

Fixes #818