### PR TITLE
Use actual useColorMode mode instead of its value from store

### DIFF
--- a/example/src/composables/useTheme.ts
+++ b/example/src/composables/useTheme.ts
@@ -1,6 +1,6 @@
 import { useColorMode } from "@vueuse/core"
 
-const { store: theme } = useColorMode({
+const theme = useColorMode({
   attribute: "data-bs-theme",
   storageKey: "theme",
   initialValue: "auto",


### PR DESCRIPTION
It prevents errors with wrong theme used at initialization. Value in store can be `auto` which isn't a theme.