### PR TITLE
escape unsafe html for PropType.list

### DIFF
--- a/src/__tests__/filters-output-escape.spec.ts
+++ b/src/__tests__/filters-output-escape.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest"
+import { formatNodeProp } from "@/filters"
+import { NodeProp } from "@/enums"
+
+describe("formatNodeProp", () => {
+  test("escapes HTML in Output list items", () => {
+    const html = formatNodeProp(NodeProp.OUTPUT, [
+      "<img src=x onerror=alert(1)>",
+    ])
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;")
+    expect(html).not.toContain("<img src=x")
+  })
+})

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -161,7 +161,7 @@ export function list(value: string[] | string): string {
     ? value.split(/\s*,\s*/)
     : value
 
-  const items = lines.map(line => `<li>${line}</li>`).join("")
+  const items = lines.map(line => `<li>${_.escape(line)}</li>`).join("")
 
   return `<ul class="list-unstyled mb-0">${items}</ul>`
 }


### PR DESCRIPTION
fixes #892.

Contrary to what I thought in the issue, OUTPUT is a list propType and not json, so I fixed it there.