### PR TITLE
fix: escape list item values to prevent HTML injection in Output node

### DIFF
--- a/src/__tests__/filters-output-escape.spec.ts
+++ b/src/__tests__/filters-output-escape.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest"
+import { formatNodeProp } from "@/filters"
+import { NodeProp } from "@/enums"
+
+describe("formatNodeProp", () => {
+  test("escapes HTML in Output list items", () => {
+    const html = formatNodeProp(NodeProp.OUTPUT, [
+      "<img src=x onerror=alert(1)>",
+    ])
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;")
+    expect(html).not.toContain("<img src=x")
+  })
+})

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -161,7 +161,7 @@ export function list(value: string[] | string): string {
     ? value.split(/\s*,\s*/)
     : value
 
-  const items = lines.map(line => `<li>${line}</li>`).join("")
+  const items = lines.map(line => `<li>${_.escape(line)}</li>`).join("")
 
   return `<ul class="list-unstyled mb-0">${items}</ul>`
 }


### PR DESCRIPTION
Fixes #892.

The Output node is rendered with `v-html` and its value goes through `list()`, which interpolated each line straight into `<li>...</li>` without escaping. A query whose output contains raw HTML (for example via `xmlelement()`) then leaked unescaped markup into the page. This escapes each line with `_.escape`, matching what `keysToString` and `sortKeys` already do, so the list still renders but tags are shown as text.
