### PR TITLE
chore: always rely on Typescript for defineProps

### DIFF
--- a/example/src/components/VLink.vue
+++ b/example/src/components/VLink.vue
@@ -1,12 +1,11 @@
 <script lang="ts" setup>
 import { inject } from "vue"
 
-const props = defineProps({
-  to: {
-    type: String,
-    required: true,
-  },
-})
+interface Props {
+  to: string
+}
+
+const props = defineProps<Props>()
 
 const currentPath = inject("currentPath")
 

--- a/src/components/SeverityBullet.vue
+++ b/src/components/SeverityBullet.vue
@@ -1,5 +1,8 @@
 <script lang="ts" setup>
-defineProps(["severity"])
+interface Props {
+  severity: string
+}
+defineProps<Props>()
 </script>
 
 <template>


### PR DESCRIPTION
It provides stronger type inference.