### PR TITLE
fix: Use Buffers instead of Blocks in BuffersDetail table

### DIFF
--- a/src/components/BuffersDetail.vue
+++ b/src/components/BuffersDetail.vue
@@ -53,7 +53,7 @@ const tempWrittenBlocks =
   <table class="table table-sm">
     <thead>
       <tr>
-        <th>Blocks</th>
+        <th>Buffers</th>
         <td class="text-end" width="25%">Hit</td>
         <td class="text-end" width="25%">Read</td>
         <td class="text-end" width="25%">Dirtied</td>

--- a/src/components/PlanStats.vue
+++ b/src/components/PlanStats.vue
@@ -205,7 +205,6 @@ const shouldShowSerializationBuffers = computed((): boolean => {
           >
         </div>
         <div v-if="shouldShowSerializationBuffers">
-          <b>Buffers: </b>
           <BuffersDetail :object="store.stats.serialization" />
         </div>
       </div>


### PR DESCRIPTION
This avoids repeating "Buffers" for example in Serialization detail dropdown.