### PR TITLE
fix: anchor cleanupSource end-of-line frame regex to avoid quadratic backtracking

### DIFF
--- a/src/services/__tests__/25-cleanup-source-backtracking.spec.ts
+++ b/src/services/__tests__/25-cleanup-source-backtracking.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest"
+import { PlanService } from "@/services/plan-service"
+import type { IPlanContent } from "@/interfaces"
+
+// Guards against catastrophic backtracking in PlanService.cleanupSource: the
+// frame-stripping regexes must stay linear so a large single-line plan is
+// cleaned quickly rather than in O(n^2) time.
+describe("PlanService cleanupSource backtracking", () => {
+  test("cleans a large single-line JSON plan quickly", () => {
+    const filter = "(a = " + "1 OR a = ".repeat(15000) + "1)"
+    const source =
+      `[{"Plan":{"Node Type":"Seq Scan","Relation Name":"t","Alias":"t",` +
+      `"Startup Cost":0.00,"Total Cost":1.00,"Plan Rows":1,"Plan Width":4,` +
+      `"Filter":"${filter}"}}]`
+
+    const planService = new PlanService()
+    const start = performance.now()
+    const json = planService.fromSource(source) as IPlanContent
+    const elapsedMs = performance.now() - start
+
+    expect(json?.Plan?.["Node Type"]).toEqual("Seq Scan")
+    expect(elapsedMs).toBeLessThan(2000)
+  }, 10000)
+})

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -410,7 +410,7 @@ export class PlanService {
     // Remove frames around, handles |, ║,
     source = source.replace(/^(\||║|│)(.*)\1\r?\n/gm, "$2\n")
     // Remove frames at the end of line, handles |, ║,
-    source = source.replace(/(.*)(\||║|│)$\r?\n/gm, "$1\n")
+    source = source.replace(/^(.*)(\||║|│)$\r?\n/gm, "$1\n")
 
     // Remove separator lines from various types of borders
     source = source.replace(/^\+-+\+\r?\n/gm, "")


### PR DESCRIPTION
The end-of-line frame-stripping regex in PlanService.cleanupSource was unanchored:
```
    /(.*)(\||║|│)$\r?\n/gm
```
These changes match from start of line exclusively:
```
    /^(.*)(\||║|│)$\r?\n/gm
```

Without the `^` restricting matches to whole lines the regex engine retries the matcher `(.*)` at every offset of a line, making the pass O(n^2) per line and pathologically slow on a large single-line plan.

Anchoring with `^` makes it linear without changing what is matched. A line with a match on the existing regex always matches the whole line from the start anyway, so the same lines are matched after the fix as before and the same frames are stripped. Existing frame-stripping tests are unchanged. A regression test covers performance on a large single-line plan.

For my particular motivating case, my plan took ~24s to render on master, and ~0.4s after these changes, with the actual regex contribution going from most of that 24s down to less than 1ms.

Likely addresses #596