### PR TITLE
fix: don't show workers info in misc

### DIFF
--- a/src/services/help-service.ts
+++ b/src/services/help-service.ts
@@ -297,6 +297,8 @@ const notMiscProperties: string[] = [
   Property.WORKERS,
   Property.WORKERS_PLANNED,
   Property.WORKERS_LAUNCHED,
+  Property.WORKERS_PLANNED_BY_GATHER,
+  Property.WORKERS_LAUNCHED_BY_GATHER,
   Property.READ_BLOCKS,
   Property.WRITTEN_BLOCKS,
   Property.EXCLUSIVE_SHARED_HIT_BLOCKS,


### PR DESCRIPTION
The "Workers [Planned|Launched] by Gather" were displayed in the Misc tab even though already shown in Workers tab.