### PR TITLE
Document release process in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,13 @@ npm run test:visual:update
 ```
 
 Visual testing via snapshots is supported by Playwright. To update or create new snapshots, run this command.
+
+## Release Process
+
+### Build library and tag version
+
+```sh
+npm version minor
+git push origin master
+git push --tags
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ npm run test:visual:update
 
 Visual testing via snapshots is supported by Playwright. To update or create new snapshots, run this command.
 
-## Release Process
+## How to release?
 
 ### Build library and tag version
 
@@ -70,3 +70,13 @@ npm version minor
 git push origin master
 git push --tags
 ```
+
+
+
+Wait for the automatic build to finish.
+
+Edit the release changelog on GitHub.
+
+An index.html file should be added automatically to the release assets by GitHub Action.
+
+### Publish to npm


### PR DESCRIPTION
Add release process instructions for versioning and tagging.
Closes #934 
Moved release instructions from the wiki into CONTRIBUTING.md so contributors can find release procedures directly in the repository documentation.