### PR TITLE
chore(parser): set time to 0 for never executed nodes

### DIFF
--- a/src/services/__tests__/plan-service.spec.ts
+++ b/src/services/__tests__/plan-service.spec.ts
@@ -269,7 +269,7 @@ Seq Scan on foo  (cost=0.00..18334.00 rows=1000000 width=37)
     expect(seqscan?.["*Plan Rows Revised"]).toBe(1000000)
   })
 
-  test("never executed node time is undefined", () => {
+  test("never executed node time is 0", () => {
     const planService = new PlanService()
     const source = `
 Hash  (cost=6.12..6.12 rows=212 width=1346) (never executed)
@@ -277,6 +277,6 @@ Hash  (cost=6.12..6.12 rows=212 width=1346) (never executed)
     const r = planService.fromSource(source) as IPlanContent
     const plan: IPlan = planService.createPlan("", r, "")
     const hash = findNodeById(plan, 1)
-    expect(hash?.["Actual Total Time"]).toBe(undefined)
+    expect(hash?.["Actual Total Time"]).toBe(0)
   })
 })

--- a/src/services/plan-service.ts
+++ b/src/services/plan-service.ts
@@ -354,10 +354,11 @@ export class PlanService {
             }
             // Value for node property should contain sub plan name (with a number
             // matching exactly)
+            // Never executed nodes (time == 0) are not taken into account
             const matches = new RegExp(
               `.*${name.replace(/[^a-zA-Z0-9]/g, "\\$&")}[0-9]?`,
             ).exec(value)
-            if (matches) {
+            if (matches && node[Property.EXCLUSIVE_DURATION]) {
               node[Property.EXCLUSIVE_DURATION] -=
                 subPlan[Property.ACTUAL_TOTAL_TIME] || 0
               // Stop iterating for this node
@@ -791,7 +792,8 @@ export class PlanService {
         if (neverExecuted) {
           newNode[Property.ACTUAL_LOOPS] = 0
           newNode[Property.ACTUAL_ROWS] = 0
-          newNode[Property.ACTUAL_TOTAL_TIME] = undefined
+          newNode[Property.ACTUAL_TOTAL_TIME] = 0
+          newNode[Property.ACTUAL_STARTUP_TIME] = 0
         }
         const element = {
           node: newNode,


### PR DESCRIPTION
By doing so, we end up with what is done in the JSON format where Actual Total|Startup Time are set to 0.000.

In order not to get negative value for exclusive duration, we don't take those nodes into account when removing time from sub plan trees.