### PR TITLE
fix(grid): show rows column when every node returned 0 row

### DIFF
--- a/src/components/Grid.vue
+++ b/src/components/Grid.vue
@@ -58,10 +58,12 @@ const ioColumns = computed((): number => {
   return _.filter([hasIORead.value, hasIOWrite.value], (v) => v).length
 })
 
+// Show the rows column as soon as actual values are available (ie. the plan
+// was run with ANALYZE), even when every node returned 0 row.
 const hasRows = computed((): boolean => {
   return _.some(store.flat, (plan: FlattenedPlanNode[]) => {
     return _.some(plan, (row: FlattenedPlanNode) => {
-      return row.node[Property.ACTUAL_ROWS_REVISED] || 0 > 1
+      return row.node[Property.ACTUAL_ROWS_REVISED] !== undefined
     })
   })
 })

--- a/src/components/GridProgressBar.vue
+++ b/src/components/GridProgressBar.vue
@@ -1,9 +1,20 @@
 <script lang="ts" setup>
+import { computed } from "vue"
+
 interface Props {
   percentage: number
   percentage2?: number
 }
-defineProps<Props>()
+const props = defineProps<Props>()
+
+// Percentages are computed from plan maximums which may be 0 or NaN (eg. a
+// plan where every node returned 0 row), leading to an invalid CSS width.
+const width = computed((): number =>
+  Number.isFinite(props.percentage) ? props.percentage : 0,
+)
+const width2 = computed((): number =>
+  Number.isFinite(props.percentage2) ? (props.percentage2 as number) : 0,
+)
 </script>
 
 <template>
@@ -11,21 +22,21 @@ defineProps<Props>()
     <div
       class="bg-secondary border-secondary opacity-50"
       :class="{
-        'border-start': percentage > 0,
+        'border-start': width > 0,
       }"
       :style="{
-        width: percentage + '%',
+        width: width + '%',
       }"
     ></div>
     <div
       class="bg-secondary border-secondary opacity-20"
       :style="{
-        width: percentage2 + '%',
+        width: width2 + '%',
       }"
       :class="{
-        'border-start': percentage2 > 0,
+        'border-start': width2 > 0,
       }"
-      v-if="percentage2"
+      v-if="width2"
     ></div>
   </div>
 </template>

--- a/src/services/__tests__/zero-actual-rows.spec.ts
+++ b/src/services/__tests__/zero-actual-rows.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest"
+import { PlanService } from "@/services/plan-service"
+import type { IPlan, IPlanContent } from "@/interfaces"
+import { findNodeById } from "@/services/help-service"
+
+// Plan where every node returned 0 row, taken from
+// https://github.com/dalibo/pev2/issues/945
+const zeroRowsPlan = `
+Nested Loop Left Join  (cost=11.95..28.52 rows=5 width=157) (actual time=0.010..0.010 rows=0 loops=1)
+  ->  Bitmap Heap Scan on public.rel_users_exams  (cost=11.80..20.27 rows=5 width=52) (actual time=0.009..0.009 rows=0 loops=1)
+        Recheck Cond: (1 = rel_users_exams.exam_id)
+        ->  Bitmap Index Scan on rel_users_exams_pkey  (cost=0.00..11.80 rows=5 width=0) (actual time=0.005..0.005 rows=0 loops=1)
+              Index Cond: (1 = rel_users_exams.exam_id)
+  ->  Materialize  (cost=0.15..8.17 rows=1 width=105) (never executed)
+        ->  Index Scan using exam_pkey on public.exam exam_1  (cost=0.15..8.17 rows=1 width=105) (never executed)
+              Index Cond: (exam_1.id = 1)
+Planning Time: 1.110 ms
+Execution Time: 0.170 ms`
+
+describe("plan with 0 actual rows", () => {
+  test("actual rows are 0, not undefined", () => {
+    const planService = new PlanService()
+    const r = planService.fromSource(zeroRowsPlan) as IPlanContent
+    const plan: IPlan = planService.createPlan("", r, "")
+
+    // Executed node
+    const nestedLoop = findNodeById(plan, 1)
+    expect(nestedLoop?.["Actual Rows"]).toBe(0)
+    expect(nestedLoop?.["*Actual Rows Revised"]).toBe(0)
+
+    // Never executed node
+    const materialize = findNodeById(plan, 4)
+    expect(materialize?.["Node Type"]).toBe("Materialize")
+    expect(materialize?.["Actual Rows"]).toBe(0)
+    expect(materialize?.["*Actual Rows Revised"]).toBe(0)
+  })
+
+  test("planned rows are still available", () => {
+    const planService = new PlanService()
+    const r = planService.fromSource(zeroRowsPlan) as IPlanContent
+    const plan: IPlan = planService.createPlan("", r, "")
+    const nestedLoop = findNodeById(plan, 1)
+    expect(nestedLoop?.["Plan Rows"]).toBe(5)
+  })
+
+  test("max rows is 0", () => {
+    const planService = new PlanService()
+    const r = planService.fromSource(zeroRowsPlan) as IPlanContent
+    const plan: IPlan = planService.createPlan("", r, "")
+    expect(plan.content.maxRows).toBe(0)
+  })
+})


### PR DESCRIPTION
Fixes #945.

## The bug

`hasRows` in `Grid.vue` reads:

```ts
return row.node[Property.ACTUAL_ROWS_REVISED] || 0 > 1
```

`>` binds tighter than `||`, so this parses as `row.node[...] || (0 > 1)`. The
`0 > 1` half is a constant `false` and contributes nothing — the guard is a plain
truthiness check on the value.

For the plan linked in the issue every node returned 0 row, so every value is
falsy and the `rows` column is hidden — even though the plan *was* run with
ANALYZE and the numbers are meaningful (planned rows are 5, and the `estim`
column stays visible because the estimate factor is non-zero).

## The fix

Show the column as soon as actual row counts are present, which is exactly the
"ANALYZE is on" condition the issue asks for. Never executed nodes already get
`Actual Rows = 0` (from 324ad36), so `!== undefined` is true for every node of an
EXPLAIN ANALYZE plan and false for a plain EXPLAIN — `07-no-analyze` still hides
the column.

I also hardened `GridProgressBar`: with this plan `store.stats.maxRows` is `0`,
so `rows / maxRows * 100` is `NaN` and got interpolated into an invalid
`style="width: NaN%"`. Non-finite percentages now fall back to `0`.

I left the other `has*` guards in `Grid.vue` alone even though they share the
same `|| 0 > 1` shape — for `time`/`estimation` the truthiness check happens to
be the behaviour you want, and changing them would alter which columns show up
on existing plans. Happy to clean them up in a follow-up if you'd prefer.

## Validation

- `npm run test` — 43 files, 218 tests pass, including the new
  `src/services/__tests__/zero-actual-rows.spec.ts` which pins down that actual
  rows are `0` (not `undefined`) for both the executed and the never-executed
  nodes of this plan, and that `maxRows` is `0`.
- `npm run typecheck` (`vue-tsc --noEmit`) clean, `eslint` clean,
  `prettier --check` clean.
- Checked in the browser against the issue's plan: the `rows` column is now
  rendered with `0` on every row. I drove it with a throwaway Playwright test
  that asserts the `rows` header is visible after switching to the grid view —
  it fails on `master` and passes with this change. I did not commit that test
  since the e2e suite here is snapshot-based and runs in Docker; let me know if
  you'd like it added as a proper visual test with updated snapshots.
